### PR TITLE
Interest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.2.1</build.version>
+        <build.version>1.3.0</build.version>
         <sonar.projectKey>BentoBoxWorld_Bank</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/world/bentobox/bank/Bank.java
+++ b/src/main/java/world/bentobox/bank/Bank.java
@@ -55,7 +55,7 @@ public class Bank extends Addon {
         config.saveConfigObject(settings);
         // Bank Manager
         bankManager = new BankManager(this);
-        bankManager.loadBalances().thenRun(() -> bankManager.startInterest());
+        bankManager.loadBalances();
         PhManager placeholderManager = new PhManager(this, bankManager);
         // Register commands with GameModes
         getPlugin().getAddonsManager().getGameModeAddons().stream()

--- a/src/main/java/world/bentobox/bank/Bank.java
+++ b/src/main/java/world/bentobox/bank/Bank.java
@@ -55,7 +55,7 @@ public class Bank extends Addon {
         config.saveConfigObject(settings);
         // Bank Manager
         bankManager = new BankManager(this);
-        bankManager.loadBalances();
+        bankManager.loadBalances().thenRun(() -> bankManager.startInterest());
         PhManager placeholderManager = new PhManager(this, bankManager);
         // Register commands with GameModes
         getPlugin().getAddonsManager().getGameModeAddons().stream()

--- a/src/main/java/world/bentobox/bank/BankManager.java
+++ b/src/main/java/world/bentobox/bank/BankManager.java
@@ -38,7 +38,7 @@ import world.bentobox.bentobox.util.Util;
 public class BankManager implements Listener {
     private static final int MAX_SIZE = 20;
     private static final double MINIMUM_INTEREST = 0.01;
-    static final long MILLISECONDS_IN_YEAR = 1000 * 60 * 60 * 24 * 365;
+    static final long MILLISECONDS_IN_YEAR = (long)1000 * 60 * 60 * 24 * 365;
     // Database handler for accounts
     private final Database<BankAccounts> handler;
     private final Bank addon;
@@ -91,9 +91,9 @@ public class BankManager implements Listener {
     Money calculateInterest(BankAccounts ba) {
         double bal = ba.getBalance().getValue();
         // Calculate compound interest over period of time
-        // A = P * (1 + r/n)^(n*t)
+        // a = P * (1 + r/n)^(n*t)
         /*
-         * A = the total value
+         * a = the total value
          * P = the initial deposit
          * r = the annual interest rate
          * n = the number of times that interest is compounded per year
@@ -102,8 +102,8 @@ public class BankManager implements Listener {
         double r = (double)addon.getSettings().getInterestRate() / 100;
         long n = addon.getSettings().getCompoundPeriodsPerYear();
         double t = getYears(System.currentTimeMillis() - ba.getInterestLastPaid());
-        double A = bal * Math.pow((1 + r/n), (n*t));
-        double interest = A - bal;
+        double a = bal * Math.pow((1 + r/n), (n*t));
+        double interest = a - bal;
         if (interest > MINIMUM_INTEREST) {
             addon.getIslands().getIslandById(ba.getUniqueId()).filter(i -> i.getOwner() != null).ifPresent(island -> {
                 // Set the interest payment timestamp
@@ -115,7 +115,7 @@ public class BankManager implements Listener {
             });
 
         }
-        return new Money(A);
+        return new Money(a);
     }
 
     private double getYears(long l) {

--- a/src/main/java/world/bentobox/bank/PhManager.java
+++ b/src/main/java/world/bentobox/bank/PhManager.java
@@ -11,6 +11,7 @@ import java.util.TreeMap;
 import org.bukkit.World;
 import org.eclipse.jdt.annotation.Nullable;
 
+import world.bentobox.bank.data.Money;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.user.User;
@@ -65,7 +66,7 @@ public class PhManager {
         // Island Balance
         plugin.getPlaceholdersManager().registerPlaceholder(addon,
                 gm.getDescription().getName().toLowerCase() + "_island_balance",
-                user -> addon.getVault().format(bankManager.getBalance(user, gm.getOverWorld())));
+                user -> addon.getVault().format(bankManager.getBalance(user, gm.getOverWorld()).getValue()));
 
         // Visited Island Balance
         plugin.getPlaceholdersManager().registerPlaceholder(addon,
@@ -74,7 +75,7 @@ public class PhManager {
         // Formatted Island Balance
         plugin.getPlaceholdersManager().registerPlaceholder(addon,
                 gm.getDescription().getName().toLowerCase() + "_island_balance_formatted",
-                user -> format(bankManager.getBalance(user, gm.getOverWorld())));
+                user -> format(bankManager.getBalance(user, gm.getOverWorld()).getValue()));
 
         // Formatted Visited Island Balance
         plugin.getPlaceholdersManager().registerPlaceholder(addon,
@@ -103,7 +104,7 @@ public class PhManager {
      */
     String getVisitedIslandBalance(GameModeAddon gm, User user, boolean formatted, boolean plain) {
         if (user == null || user.getLocation() == null) return "";
-        double balance = gm.inWorld(user.getWorld()) ? addon.getIslands().getIslandAt(user.getLocation()).map(i -> bankManager.getBalance(i)).orElse(0D) : 0D;
+        double balance = gm.inWorld(user.getWorld()) ? addon.getIslands().getIslandAt(user.getLocation()).map(i -> bankManager.getBalance(i).getValue()).orElse(0D) : 0D;
         if (plain) {
             return String.valueOf(balance);
         }
@@ -134,12 +135,12 @@ public class PhManager {
             balances.clear();
             // Get a new balance map, sort it and save it to two sorted lists
             bankManager.getBalances(world).entrySet()
-            .stream().sorted((h1, h2) -> Double.compare(h2.getValue(), h1.getValue()))
+            .stream().sorted((h1, h2) -> Money.compare(h2.getValue(), h1.getValue()))
             .limit(addon.getSettings().getRanksNumber())
             .forEach(en -> {
                 names.add(addon.getIslands().getIslandById(en.getKey())
                         .map(i -> addon.getPlayers().getName(i.getOwner())).orElse(""));
-                balances.add(addon.getVault().format(en.getValue()));
+                balances.add(addon.getVault().format(en.getValue().getValue()));
             });
             lastSorted = System.currentTimeMillis();
         }

--- a/src/main/java/world/bentobox/bank/Settings.java
+++ b/src/main/java/world/bentobox/bank/Settings.java
@@ -36,6 +36,13 @@ public class Settings implements ConfigObject {
     @ConfigEntry(path = "bank.placeholders.number-of-ranks")
     private int ranksNumber = 10;
 
+    @ConfigComment("The annual interest rate for accounts. If zero or less, interest will not be paid.")
+    private float interestRate = 10;
+
+    @ConfigComment("Period that interest is compounded in hours. Default is 1 hour; minimum is 1 minute.")
+    @ConfigComment("Make period shorter than the server reboot period otherwise interest will not be paid.")
+    private float compoundPeriod = 1;
+
     /**
      * @return the gameModes
      */
@@ -90,6 +97,36 @@ public class Settings implements ConfigObject {
      */
     public void setRanksNumber(int ranksNumber) {
         this.ranksNumber = ranksNumber;
+    }
+
+    /**
+     * @return the interestRate for this period
+     */
+    public float getInterestRate() {
+        // Interest rate is a yearly percentage. Period is hourly.
+        return interestRate / 365 / 24 / 100;
+    }
+
+    /**
+     * @param interestRate the interestRate to set
+     */
+    public void setInterestRate(float interestRate) {
+        this.interestRate = interestRate;
+    }
+
+    /**
+     * @return the compoundPeriod in ticks
+     */
+    public long getCompoundPeriod() {
+        // Make the period a minimum of 1 minute long
+        return Math.max(1200L, (long) (compoundPeriod * 72000L));
+    }
+
+    /**
+     * @param compoundPeriod the compoundPeriod to set
+     */
+    public void setCompoundPeriod(float compoundPeriod) {
+        this.compoundPeriod = compoundPeriod;
     }
 
 

--- a/src/main/java/world/bentobox/bank/Settings.java
+++ b/src/main/java/world/bentobox/bank/Settings.java
@@ -37,10 +37,10 @@ public class Settings implements ConfigObject {
     private int ranksNumber = 10;
 
     @ConfigComment("The annual interest rate for accounts. If zero or less, interest will not be paid.")
-    private float interestRate = 10;
+    private int interestRate = 10;
 
-    @ConfigComment("Period that interest is compounded in hours. Default is 1 hour; minimum is 1 minute.")
-    @ConfigComment("Make period shorter than the server reboot period otherwise interest will not be paid.")
+    @ConfigComment("Period that interest is compounded in days. Default is 1 day.")
+    @ConfigComment("Interest calculations are done when the server starts or when the player logs in.")
     private float compoundPeriod = 1;
 
     /**
@@ -100,33 +100,54 @@ public class Settings implements ConfigObject {
     }
 
     /**
-     * @return the interestRate for this period
+     * Interest rate is a yearly percentage.
+     * @return the yearly interestRate
      */
-    public float getInterestRate() {
-        // Interest rate is a yearly percentage. Period is hourly.
-        return interestRate / 365 / 24 / 100;
+    public int getInterestRate() {
+        return interestRate;
     }
 
     /**
      * @param interestRate the interestRate to set
      */
-    public void setInterestRate(float interestRate) {
+    public void setInterestRate(int interestRate) {
         this.interestRate = interestRate;
     }
 
     /**
      * @return the compoundPeriod in ticks
      */
-    public long getCompoundPeriod() {
+    public long getCompoundPeriodInTicks() {
         // Make the period a minimum of 1 minute long
-        return Math.max(1200L, (long) (compoundPeriod * 72000L));
+        return Math.max(1200L, (long) (compoundPeriod * 20 * 24 * 60 * 60));
     }
 
     /**
-     * @param compoundPeriod the compoundPeriod to set
+     * @return compound period in days
+     */
+    public float getCompoundPeriod() {
+        return compoundPeriod;
+    }
+
+    /**
+     * @return the compound periods per year
+     */
+    public long getCompoundPeriodsPerYear() {
+        return (long) (compoundPeriod * 365);
+    }
+
+    /**
+     * @param compoundPeriod the compoundPeriod to set in hours
      */
     public void setCompoundPeriod(float compoundPeriod) {
         this.compoundPeriod = compoundPeriod;
+    }
+
+    /**
+     * @return the compound period in ms
+     */
+    public long getCompoundPeriodInMs() {
+        return (long) (compoundPeriod * 24 * 60 * 60 * 1000);
     }
 
 

--- a/src/main/java/world/bentobox/bank/commands/AbstractBankCommand.java
+++ b/src/main/java/world/bentobox/bank/commands/AbstractBankCommand.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.apache.commons.lang.math.NumberUtils;
 
 import world.bentobox.bank.Bank;
+import world.bentobox.bank.data.Money;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
@@ -27,7 +28,7 @@ public abstract class AbstractBankCommand extends CompositeCommand {
 
     protected Bank addon;
     protected Island island;
-    protected double value;
+    protected Money value = new Money();
     protected User target;
 
     protected enum RequestType {
@@ -118,12 +119,12 @@ public abstract class AbstractBankCommand extends CompositeCommand {
 
     protected boolean parseValue(User user, String arg) {
         try {
-            value = Double.parseDouble(arg);
+            value = Money.parseMoney(arg);
         } catch (Exception e) {
             user.sendMessage("bank.errors.must-be-a-number");
             return false;
         }
-        if (value <= 0) {
+        if (!value.isPositive()) {
             user.sendMessage("bank.errors.value-must-be-positive");
             return false;
         }

--- a/src/main/java/world/bentobox/bank/commands/admin/AdminBalanceCommand.java
+++ b/src/main/java/world/bentobox/bank/commands/admin/AdminBalanceCommand.java
@@ -32,7 +32,8 @@ public class AdminBalanceCommand extends AbstractAdminBankCommand {
     public boolean execute(User user, String label, List<String> args) {
         user.sendMessage("bank.balance.island-balance", TextVariables.NUMBER, addon.getVault().format(addon
                 .getBankManager()
-                .getBalance(island)));
+                .getBalance(island)
+                .getValue()));
         return true;
     }
 

--- a/src/main/java/world/bentobox/bank/commands/admin/AdminGiveCommand.java
+++ b/src/main/java/world/bentobox/bank/commands/admin/AdminGiveCommand.java
@@ -41,7 +41,7 @@ public class AdminGiveCommand extends AbstractAdminBankCommand {
             if (result == BankResponse.SUCCESS) {
                 user.sendMessage("bank.admin.give.success",
                         TextVariables.NAME, this.target.getName(),
-                        TextVariables.NUMBER, addon.getVault().format(((Bank)getAddon()).getBankManager().getBalance(island)));
+                        TextVariables.NUMBER, addon.getVault().format(((Bank)getAddon()).getBankManager().getBalance(island).getValue()));
             } else {
                 user.sendMessage("bank.errors.bank-error");
             }

--- a/src/main/java/world/bentobox/bank/commands/admin/AdminSetCommand.java
+++ b/src/main/java/world/bentobox/bank/commands/admin/AdminSetCommand.java
@@ -38,7 +38,7 @@ public class AdminSetCommand extends AbstractAdminBankCommand {
         .set(user, island.getUniqueId(), value, value, TxType.SET)
         .thenAccept(result -> {
             if (result == BankResponse.SUCCESS) {
-                user.sendMessage("bank.admin.set.success", TextVariables.NAME, target.getName(), TextVariables.NUMBER, addon.getVault().format(addon.getBankManager().getBalance(island)));
+                user.sendMessage("bank.admin.set.success", TextVariables.NAME, target.getName(), TextVariables.NUMBER, addon.getVault().format(addon.getBankManager().getBalance(island).getValue()));
             } else {
                 user.sendMessage("bank.errors.bank-error");
             }

--- a/src/main/java/world/bentobox/bank/commands/admin/AdminTakeCommand.java
+++ b/src/main/java/world/bentobox/bank/commands/admin/AdminTakeCommand.java
@@ -43,7 +43,7 @@ public class AdminTakeCommand extends AbstractAdminBankCommand {
             case SUCCESS:
                 user.sendMessage("bank.admin.give.success",
                         TextVariables.NAME, this.target.getName(),
-                        TextVariables.NUMBER, addon.getVault().format(addon.getBankManager().getBalance(island)));
+                        TextVariables.NUMBER, addon.getVault().format(addon.getBankManager().getBalance(island).getValue()));
                 break;
             default:
                 user.sendMessage("bank.errors.bank-error");

--- a/src/main/java/world/bentobox/bank/commands/user/BalanceCommand.java
+++ b/src/main/java/world/bentobox/bank/commands/user/BalanceCommand.java
@@ -34,7 +34,8 @@ public class BalanceCommand extends AbstractBankCommand {
     public boolean execute(User user, String label, List<String> args) {
         user.sendMessage("bank.balance.island-balance", TextVariables.NUMBER, addon.getVault().format(addon
                 .getBankManager()
-                .getBalance(island)));
+                .getBalance(island)
+                .getValue()));
         return true;
     }
 

--- a/src/main/java/world/bentobox/bank/commands/user/DepositCommand.java
+++ b/src/main/java/world/bentobox/bank/commands/user/DepositCommand.java
@@ -5,6 +5,7 @@ import java.util.List;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 import world.bentobox.bank.commands.AbstractBankCommand;
+import world.bentobox.bank.data.Money;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
@@ -38,12 +39,12 @@ public class DepositCommand extends AbstractBankCommand {
         // Check if the player has the balance
         VaultHook vault = addon.getVault();
         double balance = vault.getBalance(user, getWorld());
-        if (balance < value) {
+        if (Money.lessThan(balance, value)) {
             user.sendMessage("bank.errors.too-much");
             return false;
         }
         // Success
-        EconomyResponse response = vault.withdraw(user, value, getWorld());
+        EconomyResponse response = vault.withdraw(user, value.getValue(), getWorld());
         if (response.type == ResponseType.SUCCESS) {
             addon.getBankManager().deposit(user, value, getWorld()).thenAccept(result -> {
                 switch (result) {
@@ -57,7 +58,7 @@ public class DepositCommand extends AbstractBankCommand {
                     user.sendMessage("general.errors.no-island");
                     break;
                 case SUCCESS:
-                    user.sendMessage("bank.deposit.success", TextVariables.NUMBER, vault.format(addon.getBankManager().getBalance(island)));
+                    user.sendMessage("bank.deposit.success", TextVariables.NUMBER, vault.format(addon.getBankManager().getBalance(island).getValue()));
                     break;
                 default:
                     break;

--- a/src/main/java/world/bentobox/bank/commands/user/WithdrawCommand.java
+++ b/src/main/java/world/bentobox/bank/commands/user/WithdrawCommand.java
@@ -3,6 +3,7 @@ package world.bentobox.bank.commands.user;
 import java.util.List;
 
 import world.bentobox.bank.commands.AbstractBankCommand;
+import world.bentobox.bank.data.Money;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
@@ -32,8 +33,8 @@ public class WithdrawCommand extends AbstractBankCommand {
             return false;
         }
         // Check if the player has the balance
-        double balance = addon.getBankManager().getBalance(user, getWorld());
-        if (balance < value) {
+        Money balance = addon.getBankManager().getBalance(user, getWorld());
+        if (Money.lessThan(balance, value)) {
             user.sendMessage("bank.errors.low-balance");
             return false;
         }
@@ -56,8 +57,8 @@ public class WithdrawCommand extends AbstractBankCommand {
                 user.sendMessage("general.errors.no-island");
                 break;
             default:
-                addon.getVault().deposit(user, value, getWorld());
-                user.sendMessage("bank.withdraw.success", TextVariables.NUMBER, addon.getVault().format(addon.getBankManager().getBalance(island)));
+                addon.getVault().deposit(user, value.getValue(), getWorld());
+                user.sendMessage("bank.withdraw.success", TextVariables.NUMBER, addon.getVault().format(addon.getBankManager().getBalance(island).getValue()));
                 break;
 
             }

--- a/src/main/java/world/bentobox/bank/commands/user/tabs/BalTopTab.java
+++ b/src/main/java/world/bentobox/bank/commands/user/tabs/BalTopTab.java
@@ -51,6 +51,8 @@ public class BalTopTab implements Tab {
     @Override
     public List<@Nullable PanelItem> getPanelItems() {
         return addon.getBankManager().getBalances(world).entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().getValue()))
+                .entrySet().stream()
                 .sorted(sort ? comparator.reversed() : comparator)
                 .limit(Objects.requireNonNull(addon.getSettings()).getRanksNumber())
                 .map(ah -> addon.getIslands().getIslandById(ah.getKey())

--- a/src/main/java/world/bentobox/bank/commands/user/tabs/StatementTab.java
+++ b/src/main/java/world/bentobox/bank/commands/user/tabs/StatementTab.java
@@ -1,6 +1,7 @@
 package world.bentobox.bank.commands.user.tabs;
 
 import java.text.DateFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumMap;
@@ -37,8 +38,9 @@ public class StatementTab implements Tab {
     private static final Map<TxType, MaterialText> ICON_TEXT;
     static {
         Map<TxType, MaterialText> ic = new EnumMap<>(TxType.class);
-        ic.put(TxType.DEPOSIT, new MaterialText(Material.GOLD_NUGGET, "deposit"));
+        ic.put(TxType.DEPOSIT, new MaterialText(Material.GOLD_INGOT, "deposit"));
         ic.put(TxType.WITHDRAW, new MaterialText(Material.WOODEN_PICKAXE, "withdrawal"));
+        ic.put(TxType.INTEREST, new MaterialText(Material.GOLD_NUGGET, "interest"));
         ic.put(TxType.SET, new MaterialText(Material.BIRCH_SIGN, "set"));
         ic.put(TxType.GIVE, new MaterialText(Material.GOLDEN_HOE, "give"));
         ic.put(TxType.TAKE, new MaterialText(Material.DARK_OAK_SIGN, "take"));
@@ -68,7 +70,19 @@ public class StatementTab implements Tab {
     @Override
     public List<@Nullable PanelItem> getPanelItems() {
         if (island == null) return Collections.emptyList();
-        return addon.getBankManager().getHistory(island).stream()
+        List<PanelItem> result = new ArrayList<>();
+        // Balance
+        result.add(new PanelItemBuilder()
+                .icon(Material.CHEST)
+                .name(user.getTranslation("bank.statement.balance.name"))
+                .description(user.getTranslation("bank.statement.balance.description",
+                        TextVariables.NUMBER,
+                        addon.getVault().format(addon
+                                .getBankManager()
+                                .getBalance(island)
+                                .getValue())))
+                .build());
+        result.addAll(addon.getBankManager().getHistory(island).stream()
                 .sorted(sort ? comparator.reversed() : comparator)
                 .map(ah -> {
                     DateFormat df = DateFormat.getDateInstance(DateFormat.SHORT, user.getLocale());
@@ -84,7 +98,8 @@ public class StatementTab implements Tab {
                                     TextVariables.NAME, ah.getName(),
                                     TextVariables.NUMBER, addon.getVault().format(ah.getAmount())));
                     return pi.icon(ICON_TEXT.get(ah.getType()).material).name(user.getTranslation("bank.statement." + ICON_TEXT.get(ah.getType()).text)).build();
-                }).collect(Collectors.toList());
+                }).collect(Collectors.toList()));
+        return result;
     }
 
     @Override

--- a/src/main/java/world/bentobox/bank/data/BankAccounts.java
+++ b/src/main/java/world/bentobox/bank/data/BankAccounts.java
@@ -21,8 +21,10 @@ public class BankAccounts implements DataObject {
     @Expose
     private String uniqueId;
 
+    /**
+     * This is only used for backward compatibility
+     */
     @Expose
-    @Deprecated
     private Double balance;
 
     @Expose

--- a/src/main/java/world/bentobox/bank/data/BankAccounts.java
+++ b/src/main/java/world/bentobox/bank/data/BankAccounts.java
@@ -22,10 +22,17 @@ public class BankAccounts implements DataObject {
     private String uniqueId;
 
     @Expose
-    private double balance;
+    @Deprecated
+    private Double balance;
+
+    @Expose
+    private Money moneyBalance;
 
     @Expose
     private final Map<Long, String> history = new TreeMap<>();
+
+    @Expose
+    private Long interestLastPaid;
 
     @Override
     public String getUniqueId() {
@@ -40,15 +47,22 @@ public class BankAccounts implements DataObject {
     /**
      * @return the balance
      */
-    public double getBalance() {
-        return balance;
+    public Money getBalance() {
+        // Backwards compatibility
+        if (balance != null && balance != 0) {
+            moneyBalance = new Money(balance);
+            balance = null;
+        } else if (moneyBalance == null) {
+            moneyBalance = new Money();
+        }
+        return moneyBalance;
     }
 
     /**
      * @param balance the balance to set
      */
-    public void setBalance(double balance) {
-        this.balance = balance;
+    public void setBalance(Money balance) {
+        this.moneyBalance = balance;
     }
 
     /**
@@ -56,6 +70,25 @@ public class BankAccounts implements DataObject {
      */
     public Map<Long, String> getHistory() {
         return history;
+    }
+
+    /**
+     * Get the timestamp for when interest was last paid
+     * @return the interestLastPaid
+     */
+    public long getInterestLastPaid() {
+        if (interestLastPaid == null) {
+            interestLastPaid = System.currentTimeMillis();
+        }
+        return interestLastPaid;
+    }
+
+    /**
+     * Set when interest was last paid
+     * @param interestLastPaid the interestLastPaid to set
+     */
+    public void setInterestLastPaid(long interestLastPaid) {
+        this.interestLastPaid = interestLastPaid;
     }
 
 }

--- a/src/main/java/world/bentobox/bank/data/Money.java
+++ b/src/main/java/world/bentobox/bank/data/Money.java
@@ -41,7 +41,7 @@ public class Money implements Comparable<Money> {
      * @param d the value to set
      */
     public void setValue(double d) {
-        this.value = new BigDecimal(d).setScale(2, RoundingMode.HALF_DOWN);
+        this.value = BigDecimal.valueOf(d).setScale(2, RoundingMode.HALF_DOWN);
     }
 
     public static Money add(@NonNull Money value1, @NonNull Money value2) {
@@ -104,7 +104,7 @@ public class Money implements Comparable<Money> {
      * @return {@code true} if the value is > 0
      */
     public boolean isPositive() {
-        return value.compareTo(BigDecimal.ZERO) == 1;
+        return value.compareTo(BigDecimal.ZERO) > 0;
     }
 
     /**

--- a/src/main/java/world/bentobox/bank/data/Money.java
+++ b/src/main/java/world/bentobox/bank/data/Money.java
@@ -1,0 +1,147 @@
+package world.bentobox.bank.data;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+import com.google.gson.annotations.Expose;
+
+/**
+ * Represents money to two decimal places
+ * @author tastybento
+ *
+ */
+public class Money implements Comparable<Money> {
+
+    @Expose
+    private BigDecimal value;
+
+    public Money(double value) {
+        setValue(value);
+    }
+
+    public Money() {
+        value = BigDecimal.ZERO;
+    }
+
+    public Money(BigDecimal bigDecimal) {
+        value = bigDecimal.setScale(2, RoundingMode.HALF_DOWN);
+    }
+
+    /**
+     * @return the value
+     */
+    public double getValue() {
+        return value.doubleValue();
+    }
+
+    /**
+     * @param d the value to set
+     */
+    public void setValue(double d) {
+        this.value = new BigDecimal(d).setScale(2, RoundingMode.HALF_DOWN);
+    }
+
+    public static Money add(@NonNull Money value1, @NonNull Money value2) {
+        return new Money(value1.getValue() + value2.getValue());
+    }
+
+    public static Money subtract(@NonNull Money value1, @NonNull Money value2) {
+        return new Money(value1.getValue() - value2.getValue());
+    }
+
+    public static Money multiply(@NonNull Money value1, @NonNull Money value2) {
+        return new Money(value1.getValue() * value2.getValue());
+    }
+
+    public static Money divide(@NonNull Money value1, @NonNull Money value2) {
+        return new Money(value1.getValue() / value2.getValue());
+    }
+
+    public static boolean lessThan(@NonNull Money value1, @NonNull Money value2) {
+        Objects.requireNonNull(value1);
+        Objects.requireNonNull(value2);
+        return value1.getValue() < value2.getValue();
+    }
+
+    public static boolean lessThan(double value1, @NonNull Money value2) {
+        return value1 < value2.getValue();
+    }
+
+    public static boolean lessThan(@NonNull Money value1, double value2) {
+        return value1.getValue() < value2;
+    }
+
+    public static boolean greaterThan(@NonNull Money value1, @NonNull Money value2) {
+        return value1.getValue() > value2.getValue();
+    }
+
+
+    @Override
+    public int compareTo(Money o) {
+        return Money.compare(this, o);
+    }
+
+    /**
+     * Compares the two specified {@code Money} values.
+     *
+     * @param   m1        the first {@code Money} to compare
+     * @param   m2        the second {@code Money} to compare
+     * @return  the value {@code 0} if {@code m1} is
+     *          numerically equal to {@code m2}; a value less than
+     *          {@code 0} if {@code d1} is numerically less than
+     *          {@code m2}; and a value greater than {@code 0}
+     *          if {@code m1} is numerically greater than
+     *          {@code m2}.
+     */
+    public static int compare(Money m1, Money m2) {
+        return m1.value.compareTo(m2.value);
+    }
+
+    /**
+     * @return {@code true} if the value is > 0
+     */
+    public boolean isPositive() {
+        return value.compareTo(BigDecimal.ZERO) == 1;
+    }
+
+    /**
+     * Returns a new {@code Money} initialized to the value
+     * represented by the specified {@code String}.
+     *
+     * @param  arg   the string to be parsed.
+     * @return the {@code Money} value represented by the string
+     *         argument.
+     * @throws NullPointerException  if the string is null
+     * @throws NumberFormatException if the string does not contain
+     *         a parsable {@code Money}.
+     */
+    public static Money parseMoney(String arg) {
+        return new Money(new BigDecimal(arg));
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Money)) {
+            return false;
+        }
+        Money other = (Money) obj;
+        return value.equals(other.value);
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+}

--- a/src/main/java/world/bentobox/bank/data/TxType.java
+++ b/src/main/java/world/bentobox/bank/data/TxType.java
@@ -22,6 +22,10 @@ public enum TxType {
      */
     SET,
     /**
+     * Interest
+     */
+    INTEREST,
+    /**
      * Unknown transaction type
      */
     UNKNOWN

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,4 @@
 # Bank Configuration ${version}
-# 
 bank:
   # BentoBox GameModes that can use Bank
   game-modes:
@@ -13,3 +12,15 @@ bank:
     user: bank
     # Admin command
     admin: bank
+  placeholders:
+    # This is how many ranks will be registered with the placeholder API.
+    # There are two placeholders per rank:
+    # %Bank_[gamemode]_top_name_1% with island level: %Bank_[gamemode]_top_value_1%
+    # [gamemode] is bskyblock, acidisland, etc.
+    number-of-ranks: 10
+  # The annual interest rate for accounts.
+  interest-rate: 10
+  # Period that interest is compounded in hours. Default 1 hour
+  # Do not make this time longer than the time your server is on before it reboots
+  compound-period: 1
+  

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -40,7 +40,10 @@ bank:
     no-rank: "&c Your rank is not high enough to use the bank."
     too-much: "&c You do not have that amount to deposit."
     value-must-be-positive: "&c Amount must be positive."
-  statement: 
+  statement:
+    balance:
+      name: "&9 Balance:"
+      description: &6 [number]
     deposit: Deposit
     description: "show your island bank history"
     give: "Admin Give"

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -44,6 +44,7 @@ bank:
     deposit: Deposit
     description: "show your island bank history"
     give: "Admin Give"
+    interest: "Interest"
     latest: "Sort by newest"
     oldest: "Sort by oldest"
     set: "Admin Set"

--- a/src/test/java/world/bentobox/bank/BankManagerTest.java
+++ b/src/test/java/world/bentobox/bank/BankManagerTest.java
@@ -273,6 +273,7 @@ public class BankManagerTest {
      */
     @Test
     public void testOnCalculateInterestOneYear10() {
+        calculate(10, 11051.56D, BankManager.MILLISECONDS_IN_YEAR);
         BankAccounts ba = new BankAccounts();
         settings.setInterestRate(10); // 10%
         ba.setBalance(new Money(10000));
@@ -284,12 +285,8 @@ public class BankManagerTest {
      * Test method for {@link world.bentobox.bank.BankManager#calculateInterest(world.bentobox.bank.data.BankAccounts)}.
      */
     @Test
-    public void testOnCalculateInterestOneYear10OneDay() {
-        BankAccounts ba = new BankAccounts();
-        settings.setInterestRate(10); // 10%
-        ba.setBalance(new Money(10000));
-        ba.setInterestLastPaid(System.currentTimeMillis() - 24 * 60 * 60 * 1000);
-        assertEquals(10058.89D, bm.calculateInterest(ba).getValue(), 0D);
+    public void testOnCalculateInterestOneDay10() {
+        calculate(10, 10002.74D, (long)24 * 60 * 60 * 1000);
     }
 
     /**
@@ -297,11 +294,7 @@ public class BankManagerTest {
      */
     @Test
     public void testOnCalculateInterestOneYear25() {
-        BankAccounts ba = new BankAccounts();
-        settings.setInterestRate(25); // 25%
-        ba.setBalance(new Money(10000));
-        ba.setInterestLastPaid(System.currentTimeMillis() - BankManager.MILLISECONDS_IN_YEAR);
-        assertEquals(12839.16D, bm.calculateInterest(ba).getValue(), 0D);
+        calculate(25, 12839.16D, BankManager.MILLISECONDS_IN_YEAR);
     }
 
     /**
@@ -309,11 +302,16 @@ public class BankManagerTest {
      */
     @Test
     public void testOnCalculateInterestOneYear0() {
+        calculate(0, 10000D, BankManager.MILLISECONDS_IN_YEAR);
+    }
+
+    private void calculate(int i, double d, long milliseconds) {
         BankAccounts ba = new BankAccounts();
-        settings.setInterestRate(0); // 0%
+        settings.setInterestRate(i); // 10%
         ba.setBalance(new Money(10000));
-        ba.setInterestLastPaid(System.currentTimeMillis() - BankManager.MILLISECONDS_IN_YEAR);
-        assertEquals(10000D, bm.calculateInterest(ba).getValue(), 0D);
+        ba.setInterestLastPaid(System.currentTimeMillis() - milliseconds);
+        assertEquals(d, bm.calculateInterest(ba).getValue(), 0D);
+
     }
 
 }

--- a/src/test/java/world/bentobox/bank/PhManagerTest.java
+++ b/src/test/java/world/bentobox/bank/PhManagerTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import world.bentobox.bank.data.Money;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.addons.AddonDescription;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -68,7 +69,7 @@ public class PhManagerTest {
     private Island island;
     @Mock
     private @Nullable Location location;
-    private Map<String, Double> map;
+    private Map<String, Money> map;
     @Mock
     private PlayersManager plm;
 
@@ -91,7 +92,7 @@ public class PhManagerTest {
         when(addon.getIslands()).thenReturn(im);
         when(user.getLocation()).thenReturn(location);
         when(im.getIslandAt(eq(location))).thenReturn(Optional.of(island));
-        when(bm.getBalance(eq(island))).thenReturn(1234.56D);
+        when(bm.getBalance(eq(island))).thenReturn(new Money(1234.56D));
         map = new LinkedHashMap<>();
         when(bm.getBalances(any())).thenReturn(map);
         when(addon.getPlayers()).thenReturn(plm);
@@ -169,7 +170,7 @@ public class PhManagerTest {
      */
     @Test
     public void testGetVisitedIslandBalanceLargest() {
-        when(bm.getBalance(eq(island))).thenReturn(Double.MAX_VALUE);
+        when(bm.getBalance(eq(island))).thenReturn(new Money(Double.MAX_VALUE));
         assertEquals("9223372T", pm.getVisitedIslandBalance(gm, user, true, false));
         assertEquals("1.7976931348623157E308", pm.getVisitedIslandBalance(gm, user, true, true));
     }
@@ -179,7 +180,7 @@ public class PhManagerTest {
      */
     @Test
     public void testGetVisitedIslandBalanceBig() {
-        when(bm.getBalance(eq(island))).thenReturn(123456789D);
+        when(bm.getBalance(eq(island))).thenReturn(new Money(123456789D));
         assertEquals("123.5M", pm.getVisitedIslandBalance(gm, user, true, false));
         assertEquals("1.23456789E8", pm.getVisitedIslandBalance(gm, user, true, true));
     }
@@ -241,23 +242,23 @@ public class PhManagerTest {
      */
     @Test
     public void testCheckCacheWithBalances() {
-        map.put(UUID.randomUUID().toString(), 123.45);
-        map.put(UUID.randomUUID().toString(), 1230.45);
-        map.put(UUID.randomUUID().toString(), 12300.45);
-        map.put(UUID.randomUUID().toString(), 12.45);
-        map.put(UUID.randomUUID().toString(), 12343.45);
-        map.put(UUID.randomUUID().toString(), 1.45);
-        map.put(UUID.randomUUID().toString(), 1345.45);
-        map.put(UUID.randomUUID().toString(), 1345.45);
-        map.put(UUID.randomUUID().toString(), 1345.45);
-        map.put(UUID.randomUUID().toString(), 100.45);
-
-        map.put(UUID.randomUUID().toString(), 10000.45);
-        map.put(UUID.randomUUID().toString(), 1000000.45);
+        map.put(UUID.randomUUID().toString(), new Money(123.45));
+        map.put(UUID.randomUUID().toString(), new Money(1230.45));
+        map.put(UUID.randomUUID().toString(), new Money(12300.45));
+        map.put(UUID.randomUUID().toString(), new Money(12.45));
+        map.put(UUID.randomUUID().toString(), new Money(12343.45));
+        map.put(UUID.randomUUID().toString(), new Money(1.45));
+        map.put(UUID.randomUUID().toString(), new Money(1345.45));
+        map.put(UUID.randomUUID().toString(), new Money(1345.45));
+        map.put(UUID.randomUUID().toString(), new Money(1345.45));
+        map.put(UUID.randomUUID().toString(), new Money(100.45));
+        map.put(UUID.randomUUID().toString(), new Money(100.4556786));
+        map.put(UUID.randomUUID().toString(), new Money(10000.45));
+        map.put(UUID.randomUUID().toString(), new Money(1000000.45));
         when(bm.getBalances(world)).thenReturn(map);
         for (int i = 1; i < 11; i++) {
             pm.checkCache(world, i);
-            assertEquals(pm.getBalances().get(i-1), "$" + map.get(pm.getNames().get(i - 1)));
+            assertEquals(pm.getBalances().get(i-1), "$" + map.get(pm.getNames().get(i - 1)).getValue());
         }
     }
 

--- a/src/test/java/world/bentobox/bank/commands/admin/AdminBalanceCommandTest.java
+++ b/src/test/java/world/bentobox/bank/commands/admin/AdminBalanceCommandTest.java
@@ -28,6 +28,7 @@ import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
+import world.bentobox.bank.data.Money;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -105,6 +106,8 @@ public class AdminBalanceCommandTest {
 
         PowerMockito.mockStatic(Util.class);
         when(Util.getWorld(any())).thenAnswer(arg -> arg.getArgument(0, World.class));
+        // Default 0 balance for unknown islands
+        when(bankManager.getBalance(any())).thenReturn(new Money());
 
         bc = new AdminBalanceCommand(ic);
     }

--- a/src/test/java/world/bentobox/bank/commands/admin/AdminGiveCommandTest.java
+++ b/src/test/java/world/bentobox/bank/commands/admin/AdminGiveCommandTest.java
@@ -30,6 +30,7 @@ import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
 import world.bentobox.bank.BankResponse;
+import world.bentobox.bank.data.Money;
 import world.bentobox.bank.data.TxType;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -106,8 +107,9 @@ public class AdminGiveCommandTest {
         EconomyResponse er = new EconomyResponse(0, 0, ResponseType.SUCCESS, "");
         when(vh.withdraw(eq(user), anyDouble(), eq(world))).thenReturn(er);
         // Always successful giving
-        when(bankManager.deposit(eq(user), any(), anyDouble(), eq(TxType.GIVE))).thenReturn(CompletableFuture.completedFuture(BankResponse.SUCCESS));
-
+        when(bankManager.deposit(eq(user), any(), any(Money.class), eq(TxType.GIVE))).thenReturn(CompletableFuture.completedFuture(BankResponse.SUCCESS));
+        // Default 0 balance for unknown islands
+        when(bankManager.getBalance(any())).thenReturn(new Money());
 
         bc = new AdminGiveCommand(ic);
     }
@@ -215,7 +217,7 @@ public class AdminGiveCommandTest {
      */
     @Test
     public void testExecuteUserStringListOfStringError() {
-        when(bankManager.deposit(eq(user), any(), anyDouble(), eq(TxType.GIVE))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOAD_ERROR));
+        when(bankManager.deposit(eq(user), any(), any(Money.class), eq(TxType.GIVE))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOAD_ERROR));
         assertTrue(bc.execute(user, "give", Arrays.asList("tastybento", "100")));
         verify(user).sendMessage(eq("bank.errors.bank-error"));
     }

--- a/src/test/java/world/bentobox/bank/commands/admin/AdminSetCommandTest.java
+++ b/src/test/java/world/bentobox/bank/commands/admin/AdminSetCommandTest.java
@@ -31,6 +31,7 @@ import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
 import world.bentobox.bank.BankResponse;
+import world.bentobox.bank.data.Money;
 import world.bentobox.bank.data.TxType;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -107,8 +108,8 @@ public class AdminSetCommandTest {
         EconomyResponse er = new EconomyResponse(0, 0, ResponseType.SUCCESS, "");
         when(vh.withdraw(eq(user), anyDouble(), eq(world))).thenReturn(er);
         // Always successful setting
-        when(bankManager.set(eq(user), anyString(), anyDouble(), anyDouble(), eq(TxType.SET))).thenReturn(CompletableFuture.completedFuture(BankResponse.SUCCESS));
-        when(bankManager.getBalance(eq(island))).thenReturn(100D);
+        when(bankManager.set(eq(user), anyString(), any(), any(), eq(TxType.SET))).thenReturn(CompletableFuture.completedFuture(BankResponse.SUCCESS));
+        when(bankManager.getBalance(eq(island))).thenReturn(new Money(100D));
         // Island
         when(island.getUniqueId()).thenReturn(UUID.randomUUID().toString());
 
@@ -217,7 +218,7 @@ public class AdminSetCommandTest {
     @Test
     public void testExecuteUserStringListOfStringError() {
         testCanExecuteSuccess();
-        when(bankManager.set(eq(user), any(), anyDouble(), anyDouble(), eq(TxType.SET))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOAD_ERROR));
+        when(bankManager.set(eq(user), any(), any(), any(), eq(TxType.SET))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOAD_ERROR));
         assertTrue(bc.execute(user, "set", Arrays.asList("tastybento", "100")));
         verify(user).sendMessage(eq("bank.errors.bank-error"));
     }

--- a/src/test/java/world/bentobox/bank/commands/admin/AdminTakeCommandTest.java
+++ b/src/test/java/world/bentobox/bank/commands/admin/AdminTakeCommandTest.java
@@ -30,6 +30,7 @@ import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
 import world.bentobox.bank.BankResponse;
+import world.bentobox.bank.data.Money;
 import world.bentobox.bank.data.TxType;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
@@ -107,8 +108,9 @@ public class AdminTakeCommandTest {
         EconomyResponse er = new EconomyResponse(0, 0, ResponseType.SUCCESS, "");
         when(vh.withdraw(eq(user), anyDouble(), eq(world))).thenReturn(er);
         // Always successful taking
-        when(bankManager.withdraw(eq(user), any(), anyDouble(), eq(TxType.TAKE))).thenReturn(CompletableFuture.completedFuture(BankResponse.SUCCESS));
-
+        when(bankManager.withdraw(eq(user), any(), any(), eq(TxType.TAKE))).thenReturn(CompletableFuture.completedFuture(BankResponse.SUCCESS));
+        // set default balance to 0 for unknown island
+        when(bankManager.getBalance(any())).thenReturn(new Money());
 
         bc = new AdminTakeCommand(ic);
     }
@@ -217,7 +219,7 @@ public class AdminTakeCommandTest {
     @Test
     public void testExecuteUserStringListOfStringLowBalance() {
         testCanExecuteSuccess();
-        when(bankManager.withdraw(eq(user), any(), anyDouble(), eq(TxType.TAKE))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOW_BALANCE));
+        when(bankManager.withdraw(eq(user), any(), any(), eq(TxType.TAKE))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOW_BALANCE));
         assertTrue(bc.execute(user, "take", Arrays.asList("tastybento", "100")));
         verify(user).sendMessage(eq("bank.errors.too-low"));
     }
@@ -227,7 +229,7 @@ public class AdminTakeCommandTest {
      */
     @Test
     public void testExecuteUserStringListOfStringError() {
-        when(bankManager.withdraw(eq(user), any(), anyDouble(), eq(TxType.TAKE))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOAD_ERROR));
+        when(bankManager.withdraw(eq(user), any(), any(), eq(TxType.TAKE))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOAD_ERROR));
         assertTrue(bc.execute(user, "take", Arrays.asList("tastybento", "100")));
         verify(user).sendMessage(eq("bank.errors.bank-error"));
     }

--- a/src/test/java/world/bentobox/bank/commands/user/BalanceCommandTest.java
+++ b/src/test/java/world/bentobox/bank/commands/user/BalanceCommandTest.java
@@ -27,6 +27,7 @@ import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
+import world.bentobox.bank.data.Money;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -98,6 +99,8 @@ public class BalanceCommandTest {
 
         PowerMockito.mockStatic(Util.class);
         when(Util.getWorld(any())).thenAnswer(arg -> arg.getArgument(0, World.class));
+
+        when(bankManager.getBalance(any())).thenReturn(new Money());
 
         bc = new BalanceCommand(ic);
     }

--- a/src/test/java/world/bentobox/bank/commands/user/DepositCommandTest.java
+++ b/src/test/java/world/bentobox/bank/commands/user/DepositCommandTest.java
@@ -30,6 +30,7 @@ import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
 import world.bentobox.bank.BankResponse;
+import world.bentobox.bank.data.Money;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -97,7 +98,7 @@ public class DepositCommandTest {
 
         when(ic.getAddon()).thenReturn(addon);
         when(addon.getBankManager()).thenReturn(bankManager);
-        when(bankManager.getBalance(eq(island))).thenReturn(100D);
+        when(bankManager.getBalance(eq(island))).thenReturn(new Money(100D));
         when(addon.getVault()).thenReturn(vh);
         when(vh.getBalance(eq(user), eq(world))).thenReturn(1000D);
         when(vh.format(anyDouble())).thenAnswer(i -> String.valueOf(i.getArgument(0, Double.class)));
@@ -173,7 +174,7 @@ public class DepositCommandTest {
      */
     @Test
     public void testCanExecuteOneArgNumberSuccess() {
-        when(bankManager.getBalance(eq(user), eq(world))).thenReturn(555D);
+        when(bankManager.getBalance(eq(user), eq(world))).thenReturn(new Money(555D));
         assertTrue(dct.canExecute(user, "deposit", Collections.singletonList("123.30")));
         verify(user, never()).sendMessage(any());
     }
@@ -183,7 +184,7 @@ public class DepositCommandTest {
      */
     @Test
     public void testExecuteUserStringListOfStringLoadError() {
-        when(bankManager.deposit(eq(user), anyDouble(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOAD_ERROR));
+        when(bankManager.deposit(eq(user), any(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOAD_ERROR));
 
         assertTrue(dct.execute(user, "deposit", Collections.emptyList()));
         verify(user).sendMessage("bank.errors.bank-error");
@@ -205,7 +206,7 @@ public class DepositCommandTest {
      */
     @Test
     public void testExecuteUserStringListOfStringLowBalance() {
-        when(bankManager.deposit(eq(user), anyDouble(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOW_BALANCE));
+        when(bankManager.deposit(eq(user), any(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOW_BALANCE));
 
         assertTrue(dct.execute(user, "deposit", Collections.emptyList()));
         verify(user).sendMessage("bank.errors.low-balance");
@@ -216,7 +217,7 @@ public class DepositCommandTest {
      */
     @Test
     public void testExecuteUserStringListOfStringNoIsland() {
-        when(bankManager.deposit(eq(user), anyDouble(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_NO_ISLAND));
+        when(bankManager.deposit(eq(user), any(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_NO_ISLAND));
         assertTrue(dct.execute(user, "deposit", Collections.emptyList()));
         verify(user).sendMessage("general.errors.no-island");
     }
@@ -227,7 +228,7 @@ public class DepositCommandTest {
     @Test
     public void testExecuteUserStringListOfStringSuccess() {
         testCanExecuteOneArgNumberSuccess();
-        when(bankManager.deposit(eq(user), anyDouble(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.SUCCESS));
+        when(bankManager.deposit(eq(user), any(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.SUCCESS));
         assertTrue(dct.execute(user, "deposit", Collections.singletonList("123.30")));
         verify(vh).withdraw(eq(user), eq(123.3D), eq(world));
         verify(user).sendMessage(eq("bank.deposit.success"), eq(TextVariables.NUMBER), eq("100.0"));
@@ -238,7 +239,7 @@ public class DepositCommandTest {
      */
     @Test
     public void testCanExecuteOneArgNumberLowBalance() {
-        when(bankManager.deposit(eq(user), anyDouble(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOW_BALANCE));
+        when(bankManager.deposit(eq(user), any(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOW_BALANCE));
         assertTrue(dct.execute(user, "deposit", Collections.singletonList("123.30")));
         verify(user).sendMessage(eq("bank.errors.low-balance"));
     }

--- a/src/test/java/world/bentobox/bank/commands/user/WithdrawCommandTest.java
+++ b/src/test/java/world/bentobox/bank/commands/user/WithdrawCommandTest.java
@@ -27,6 +27,7 @@ import org.powermock.reflect.Whitebox;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
 import world.bentobox.bank.BankResponse;
+import world.bentobox.bank.data.Money;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
@@ -95,7 +96,8 @@ public class WithdrawCommandTest {
 
         when(ic.getAddon()).thenReturn(addon);
         when(addon.getBankManager()).thenReturn(bankManager);
-        when(bankManager.getBalance(eq(island))).thenReturn(100D);
+        when(bankManager.getBalance(any(), any())).thenReturn(new Money());
+        when(bankManager.getBalance(eq(island))).thenReturn(new Money(100D));
         when(addon.getVault()).thenReturn(vh);
         when(vh.format(anyDouble())).thenAnswer(i -> String.valueOf(i.getArgument(0, Double.class)));
 
@@ -179,7 +181,7 @@ public class WithdrawCommandTest {
      */
     @Test
     public void testCanExecuteOneArgNumberSuccess() {
-        when(bankManager.getBalance(eq(user), eq(world))).thenReturn(555D);
+        when(bankManager.getBalance(eq(user), eq(world))).thenReturn(new Money(555D));
         assertTrue(wct.canExecute(user, "withdraw", Collections.singletonList("123.30")));
         verify(user, never()).sendMessage(any());
     }
@@ -189,7 +191,7 @@ public class WithdrawCommandTest {
      */
     @Test
     public void testExecuteUserStringListOfStringLoadError() {
-        when(bankManager.withdraw(eq(user), anyDouble(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOAD_ERROR));
+        when(bankManager.withdraw(eq(user), any(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOAD_ERROR));
         //testCanExecuteOneArgNumberSuccess();
         assertTrue(wct.execute(user, "withdraw", Collections.emptyList()));
         verify(user).sendMessage("bank.errors.bank-error");
@@ -200,7 +202,7 @@ public class WithdrawCommandTest {
      */
     @Test
     public void testExecuteUserStringListOfStringLowBalance() {
-        when(bankManager.withdraw(eq(user), anyDouble(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOW_BALANCE));
+        when(bankManager.withdraw(eq(user), any(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_LOW_BALANCE));
         //testCanExecuteOneArgNumberSuccess();
         assertTrue(wct.execute(user, "withdraw", Collections.emptyList()));
         verify(user).sendMessage("bank.errors.low-balance");
@@ -211,7 +213,7 @@ public class WithdrawCommandTest {
      */
     @Test
     public void testExecuteUserStringListOfStringNoIsland() {
-        when(bankManager.withdraw(eq(user), anyDouble(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_NO_ISLAND));
+        when(bankManager.withdraw(eq(user), any(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.FAILURE_NO_ISLAND));
         //testCanExecuteOneArgNumberSuccess();
         assertTrue(wct.execute(user, "withdraw", Collections.emptyList()));
         verify(user).sendMessage("general.errors.no-island");
@@ -223,7 +225,7 @@ public class WithdrawCommandTest {
     @Test
     public void testExecuteUserStringListOfStringSuccess() {
         testCanExecuteOneArgNumberSuccess();
-        when(bankManager.withdraw(eq(user), anyDouble(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.SUCCESS));
+        when(bankManager.withdraw(eq(user), any(), eq(world))).thenReturn(CompletableFuture.completedFuture(BankResponse.SUCCESS));
         //testCanExecuteOneArgNumberSuccess();
         assertTrue(wct.execute(user, "withdraw", Collections.singletonList("123.30")));
         verify(vh).deposit(eq(user), eq(123.3D), eq(world));

--- a/src/test/java/world/bentobox/bank/data/MoneyTest.java
+++ b/src/test/java/world/bentobox/bank/data/MoneyTest.java
@@ -1,0 +1,224 @@
+package world.bentobox.bank.data;
+
+import static org.junit.Assert.*;
+
+import java.math.BigDecimal;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @author tastybento
+ *
+ */
+@RunWith(PowerMockRunner.class)
+public class MoneyTest {
+
+    Money m;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        m = new Money();
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#hashCode()}.
+     */
+    @Test
+    public void testHashCode() {
+        assertEquals(0, m.hashCode());
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#Money(double)}.
+     */
+    @Test
+    public void testMoneyDouble() {
+        m = new Money(123.45678D);
+        assertEquals(123.46D, m.getValue(), 0D);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#Money()}.
+     */
+    @Test
+    public void testMoney() {
+        assertEquals(0D, m.getValue(), 0D);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#Money(java.math.BigDecimal)}.
+     */
+    @Test
+    public void testMoneyBigDecimal() {
+        m = new Money(BigDecimal.valueOf(123.45678));
+        assertEquals(123.46D, m.getValue(), 0D);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#setValue(double)}.
+     */
+    @Test
+    public void testSetValue() {
+        m.setValue(12345.6789D);
+        assertEquals(12345.68D, m.getValue(), 0D);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#add(world.bentobox.bank.data.Money, world.bentobox.bank.data.Money)}.
+     */
+    @Test
+    public void testAdd() {
+        assertEquals(new Money(579), Money.add(new Money(123), new Money(456)));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#subtract(world.bentobox.bank.data.Money, world.bentobox.bank.data.Money)}.
+     */
+    @Test
+    public void testSubtract() {
+        assertEquals(new Money(-333), Money.subtract(new Money(123), new Money(456)));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#multiply(world.bentobox.bank.data.Money, world.bentobox.bank.data.Money)}.
+     */
+    @Test
+    public void testMultiply() {
+        assertEquals(new Money(18), Money.multiply(new Money(3), new Money(6)));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#divide(world.bentobox.bank.data.Money, world.bentobox.bank.data.Money)}.
+     */
+    @Test
+    public void testDivide() {
+        assertEquals(3.71, Money.divide(new Money(456), new Money(123)).getValue(), 0D);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#lessThan(world.bentobox.bank.data.Money, world.bentobox.bank.data.Money)}.
+     */
+    @Test
+    public void testLessThanMoneyMoney() {
+        assertFalse(Money.lessThan(new Money(456), new Money(123)));
+        assertTrue(Money.lessThan(new Money(456), new Money(1235)));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#lessThan(double, world.bentobox.bank.data.Money)}.
+     */
+    @Test
+    public void testLessThanDoubleMoney() {
+        assertFalse(Money.lessThan(456, new Money(123)));
+        assertTrue(Money.lessThan(456, new Money(1235)));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#lessThan(world.bentobox.bank.data.Money, double)}.
+     */
+    @Test
+    public void testLessThanMoneyDouble() {
+        assertFalse(Money.lessThan(new Money(456), 123));
+        assertTrue(Money.lessThan(new Money(456), 1235));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#greaterThan(world.bentobox.bank.data.Money, world.bentobox.bank.data.Money)}.
+     */
+    @Test
+    public void testGreaterThan() {
+        assertTrue(Money.greaterThan(new Money(456), new Money(123)));
+        assertFalse(Money.greaterThan(new Money(456), new Money(1235)));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#compareTo(world.bentobox.bank.data.Money)}.
+     */
+    @Test
+    public void testCompareTo() {
+        m = new Money(456);
+        assertTrue(m.compareTo(new Money(123)) > 0);
+        assertTrue(m.compareTo(new Money(456)) == 0);
+        assertTrue(m.compareTo(new Money(1230)) < 0);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#compare(world.bentobox.bank.data.Money, world.bentobox.bank.data.Money)}.
+     */
+    @Test
+    public void testCompare() {
+        assertTrue(Money.compare(new Money(456), new Money(123)) > 0);
+        assertTrue(Money.compare(new Money(456), new Money(456)) == 0);
+        assertTrue(Money.compare(new Money(456), new Money(1230)) < 0);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#isPositive()}.
+     */
+    @Test
+    public void testIsPositive() {
+        assertFalse(m.isPositive());
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#parseMoney(java.lang.String)}.
+     */
+    @Test(expected = NullPointerException.class)
+    public void testParseMoneyNPE() {
+        Money.parseMoney(null);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#parseMoney(java.lang.String)}.
+     */
+    @Test(expected = NumberFormatException.class)
+    public void testParseMoneyNFE() {
+        Money.parseMoney("tastybento");
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#parseMoney(java.lang.String)}.
+     */
+    @Test
+    public void testParseMoney() {
+        assertEquals(123.45, Money.parseMoney("123.45").getValue(), 0D);
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#equals(java.lang.Object)}.
+     */
+    @SuppressWarnings("unlikely-arg-type")
+    @Test
+    public void testEqualsObject() {
+        assertTrue(m.equals(m));
+        assertFalse(m.equals("string"));
+        assertFalse(m.equals(null));
+        assertFalse(m.equals(new Money(123)));
+        m = new Money(345);
+        assertTrue(m.equals(new Money(345)));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.bank.data.Money#toString()}.
+     */
+    @Test
+    public void testToString() {
+        m = new Money(1234.56789);
+        assertEquals("1234.57", m.toString());
+    }
+
+}

--- a/src/test/java/world/bentobox/bank/data/MoneyTest.java
+++ b/src/test/java/world/bentobox/bank/data/MoneyTest.java
@@ -152,7 +152,7 @@ public class MoneyTest {
     public void testCompareTo() {
         m = new Money(456);
         assertTrue(m.compareTo(new Money(123)) > 0);
-        assertTrue(m.compareTo(new Money(456)) == 0);
+        assertEquals(0, m.compareTo(new Money(456)));
         assertTrue(m.compareTo(new Money(1230)) < 0);
     }
 
@@ -162,7 +162,7 @@ public class MoneyTest {
     @Test
     public void testCompare() {
         assertTrue(Money.compare(new Money(456), new Money(123)) > 0);
-        assertTrue(Money.compare(new Money(456), new Money(456)) == 0);
+        assertEquals(0, Money.compare(new Money(456), new Money(456)));
         assertTrue(Money.compare(new Money(456), new Money(1230)) < 0);
     }
 


### PR DESCRIPTION
Fixes https://github.com/BentoBoxWorld/Bank/issues/12

Adds interest to bank account. The interest is the yearly interest rate because that is what is used in real life. Interest is compounded (calculated) on a daily period by default but interest is paid intermittently and triggered only by actions to avoid a long-running task timer and period mass updates of accounts that could cause lag. When the server is started, interest calculated for all accounts and accounts updated. Interest payment checks are made with every deposit or withdrawal by the player. 

Example:

1. Player deposits 10,000 to their account
2. Player logs off
3. One week passes, during which the server is rebooted 3 times.
4. When the player logs on, they check their balance and see it is larger than 10,000
5. The player checks their statement and sees they have at least 3 interest payments
6. They make a withdrawal of 1,000 - at this time, if it has been more than a day since interest was paid, then any outstanding interest is paid before the withdrawal.
7. The player sees they have more money than they expected.
8. They look at their statement and see interest was just paid.

Players see interest in their account as a golden nugget as if it was deposited by the island owner. Deposits have a new icon - golden ingot. 

As you can see, interest is actually quite complex and to make it scalable, it can be a little weird, but in the end, the players will get paid their due.
