### PR TITLE
Add Russian locale and all missing BentoBox languages

### DIFF
--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -33,6 +33,7 @@ bank:
     description: vložte částku na svůj ostrovní účet
     parameters: "<množství>"
     success: "&a Úspěch! Váš nový zůstatek na ostrovní bance je [number]."
+    alert: "&a [name] vložil [number] do ostrovní banky."
   errors:
     bank-error: "&c Chyba při načítání informací o bankovním účtu - zkuste to znovu
       později"
@@ -70,6 +71,7 @@ bank:
     description: vybrat částku ze svého ostrovního účtu
     parameters: "<množství>"
     success: "&a Úspěch! Váš nový zůstatek na ostrovní bance je [number]."
+    alert: "&a [name] vybral [number] z ostrovní banky."
 protection:
   flags:
     BANK_ACCESS:

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -33,6 +33,7 @@ bank:
     description: Betrag auf Ihr Inselkonto einzahlen
     parameters: "<amount>"
     success: "&ein Erfolg! Ihr neuer Kontostand auf der Insel beträgt [number]."
+    alert: "&a [name] hat [number] in die Inselbank eingezahlt."
   errors:
     bank-error: "&c Fehler beim Laden der Bankkontoinformationen - bitte versuchen
       Sie es später erneut"
@@ -70,6 +71,7 @@ bank:
     description: Betrag von Ihrem Inselkonto abheben
     parameters: "<amount>"
     success: "&ein Erfolg! Ihr neuer Kontostand auf der Insel beträgt [number]."
+    alert: "&a [name] hat [number] von der Inselbank abgehoben."
 protection:
   flags:
     BANK_ACCESS:

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -1,0 +1,81 @@
+---
+bank:
+  admin:
+    description: admin naredba za otočnu banku
+    give:
+      parameters: "<player> <amount>"
+      description: dodaj iznos na igračev otočni račun
+      success: "&a Uspjeh! Stanje otočne banke igrača [name] sada je [number]."
+    take:
+      parameters: "<player> <amount>"
+      description: uzmi iznos s igračeva otočnog računa
+    balance:
+      parameters: "<player>"
+      description: prikaži stanje igračeva otočnog računa
+    set:
+      parameters: "<player> <amount>"
+      description: postavi iznos na igračevu otočnom računu
+      success: "&a Račun igrača [name] postavljen je na [number]."
+    statement:
+      parameters: "<player>"
+      description: prikaži izvod otočne banke za igrača
+  balance:
+    description: prikazuje stanje vaše otočne banke
+    island-balance: "&a Stanje otočne banke je [number]."
+  baltop:
+    description: prikaži poredak po stanju
+    description-syntax: "&d [number]"
+    highest: Poredaj po najvišem
+    lowest: Poredaj po najnižem
+    name-syntax: "&d [name]"
+    title: Najveća stanja
+  deposit:
+    description: položi iznos na svoj otočni račun
+    parameters: "<amount>"
+    success: "&a Uspjeh! Vaše novo stanje otočne banke je [number]."
+    alert: "&a [name] je položio [number] u otočnu banku."
+  errors:
+    bank-error: "&c Pogreška pri učitavanju podataka o bankovnom računu - pokušajte
+      ponovno kasnije"
+    low-balance: "&c Stanje vaše otočne banke nije dovoljno visoko!"
+    too-low: "&c Stanje otoka je prenisko."
+    must-be-a-number: "&c Iznos mora biti broj"
+    no-rank: "&c Vaš rang nije dovoljno visok za korištenje banke."
+    too-much: "&c Nemate toliki iznos za polaganje."
+    value-must-be-positive: "&c Iznos mora biti pozitivan."
+    scientific: "&c Znanstveni zapis nije podržan."
+    too-long: "&c Vrijednost mora imati manje od 10 znamenki"
+  statement:
+    balance:
+      name: "&9 Stanje:"
+      description: "&6 [number]"
+    deposit: Polog
+    description: prikaži povijest vaše otočne banke
+    give: Admin dodjela
+    interest: Kamate
+    latest: Poredaj po najnovijem
+    oldest: Poredaj po najstarijem
+    set: Admin postavljanje
+    syntax: |
+        &9 [date]
+        &9 [time]
+        &7 [name]
+        &6 [number]
+    take: Admin oduzimanje
+    title: Povijest računa
+    unknown: Nepoznata vrsta
+    withdrawal: Podizanje
+  user:
+    description: naredba otočne banke
+  withdraw:
+    description: podigni iznos sa svog otočnog računa
+    parameters: "<amount>"
+    success: "&a Uspjeh! Vaše novo stanje otočne banke je [number]."
+    alert: "&a [name] je podigao [number] iz otočne banke."
+protection:
+  flags:
+    BANK_ACCESS:
+      description: |-
+          &f Dopusti pristup
+          &f otočnoj banci
+      name: Pristup otočnoj banci

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -1,0 +1,81 @@
+---
+bank:
+  admin:
+    description: admin parancs a sziget bankhoz
+    give:
+      parameters: "<player> <amount>"
+      description: összeg hozzáadása a játékos sziget számlájához
+      success: "&a Siker! [name] sziget bankegyenlege most [number]."
+    take:
+      parameters: "<player> <amount>"
+      description: összeg levonása a játékos sziget számlájáról
+    balance:
+      parameters: "<player>"
+      description: a játékos sziget számlájának egyenlege
+    set:
+      parameters: "<player> <amount>"
+      description: összeg beállítása a játékos sziget számláján
+      success: "&a [name] számlája [number] értékre állítva."
+    statement:
+      parameters: "<player>"
+      description: a játékos sziget bank kivonatának megtekintése
+  balance:
+    description: megmutatja a sziget bankegyenlegedet
+    island-balance: "&a A sziget bankegyenlege [number]."
+  baltop:
+    description: egyenleg rangsor megjelenítése
+    description-syntax: "&d [number]"
+    highest: Rendezés a legmagasabb szerint
+    lowest: Rendezés a legalacsonyabb szerint
+    name-syntax: "&d [name]"
+    title: Legjobb egyenlegek
+  deposit:
+    description: összeg befizetése a sziget számládra
+    parameters: "<amount>"
+    success: "&a Siker! Az új sziget bankegyenleged [number]."
+    alert: "&a [name] befizetett [number] összeget a sziget bankba."
+  errors:
+    bank-error: "&c Hiba a bankszámla adatainak betöltésekor - kérlek próbáld újra
+      később"
+    low-balance: "&c A sziget bankegyenleged nem elég magas!"
+    too-low: "&c A sziget egyenlege túl alacsony."
+    must-be-a-number: "&c Az összegnek számnak kell lennie"
+    no-rank: "&c A rangod nem elég magas a bank használatához."
+    too-much: "&c Nincs ennyi befizetni való összeged."
+    value-must-be-positive: "&c Az összegnek pozitívnak kell lennie."
+    scientific: "&c A tudományos jelölés nem támogatott."
+    too-long: "&c Az értéknek kevesebb mint 10 számjegyűnek kell lennie"
+  statement:
+    balance:
+      name: "&9 Egyenleg:"
+      description: "&6 [number]"
+    deposit: Befizetés
+    description: a sziget bank előzményeinek megjelenítése
+    give: Admin adás
+    interest: Kamat
+    latest: Rendezés a legújabb szerint
+    oldest: Rendezés a legrégebbi szerint
+    set: Admin beállítás
+    syntax: |
+        &9 [date]
+        &9 [time]
+        &7 [name]
+        &6 [number]
+    take: Admin elvétel
+    title: Számlatörténet
+    unknown: Ismeretlen típus
+    withdrawal: Kivétel
+  user:
+    description: sziget bank parancs
+  withdraw:
+    description: összeg kivétele a sziget számládról
+    parameters: "<amount>"
+    success: "&a Siker! Az új sziget bankegyenleged [number]."
+    alert: "&a [name] kivett [number] összeget a sziget bankból."
+protection:
+  flags:
+    BANK_ACCESS:
+      description: |-
+          &f Hozzáférés engedélyezése
+          &f a sziget bankhoz
+      name: Sziget bank hozzáférés

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -33,6 +33,7 @@ bank:
     description: 島の口座に入金金額
     parameters: "<金額>"
     success: "&a成功！新しい島の銀行の残高は[number]です。"
+    alert: "&a[name]が島の銀行に[number]を入金しました。"
   errors:
     bank-error: "&c銀行口座情報の読み込み中にエラーが発生しました-後でもう一度お試しください"
     low-balance: "&cあなたの島の銀行の残高は十分に高くありません！"
@@ -65,6 +66,7 @@ bank:
     description: アイランドアカウントから金額を引き出す
     parameters: "<金額>"
     success: "&a成功！新しい島の銀行の残高は[number]です。"
+    alert: "&a[name]が島の銀行から[number]を引き出しました。"
 protection:
   flags:
     BANK_ACCESS:

--- a/src/main/resources/locales/lv.yml
+++ b/src/main/resources/locales/lv.yml
@@ -1,0 +1,81 @@
+---
+bank:
+  admin:
+    description: administratora komanda salas bankai
+    give:
+      parameters: "<player> <amount>"
+      description: pievienot summu spēlētāja salas kontam
+      success: "&a Veiksmīgi! Spēlētāja [name] salas bankas atlikums tagad ir [number]."
+    take:
+      parameters: "<player> <amount>"
+      description: noņemt summu no spēlētāja salas konta
+    balance:
+      parameters: "<player>"
+      description: skatīt spēlētāja salas konta atlikumu
+    set:
+      parameters: "<player> <amount>"
+      description: iestatīt summu spēlētāja salas kontā
+      success: "&a Spēlētāja [name] konts iestatīts uz [number]."
+    statement:
+      parameters: "<player>"
+      description: skatīt spēlētāja salas bankas izrakstu
+  balance:
+    description: parāda jūsu salas bankas atlikumu
+    island-balance: "&a Salas bankas atlikums ir [number]."
+  baltop:
+    description: rādīt atlikumu reitingu
+    description-syntax: "&d [number]"
+    highest: Kārtot pēc augstākā
+    lowest: Kārtot pēc zemākā
+    name-syntax: "&d [name]"
+    title: Lielākie atlikumi
+  deposit:
+    description: iemaksāt summu jūsu salas kontā
+    parameters: "<amount>"
+    success: "&a Veiksmīgi! Jūsu jaunais salas bankas atlikums ir [number]."
+    alert: "&a [name] iemaksāja [number] salas bankā."
+  errors:
+    bank-error: "&c Kļūda, ielādējot bankas konta informāciju - lūdzu, mēģiniet vēlreiz
+      vēlāk"
+    low-balance: "&c Jūsu salas bankas atlikums nav pietiekami liels!"
+    too-low: "&c Salas atlikums ir pārāk zems."
+    must-be-a-number: "&c Summai jābūt skaitlim"
+    no-rank: "&c Jūsu rangs nav pietiekami augsts, lai izmantotu banku."
+    too-much: "&c Jums nav tādas summas, ko iemaksāt."
+    value-must-be-positive: "&c Summai jābūt pozitīvai."
+    scientific: "&c Zinātniskais pieraksts netiek atbalstīts."
+    too-long: "&c Vērtībai jābūt mazākai par 10 cipariem"
+  statement:
+    balance:
+      name: "&9 Atlikums:"
+      description: "&6 [number]"
+    deposit: Iemaksa
+    description: parādīt jūsu salas bankas vēsturi
+    give: Administratora piešķīrums
+    interest: Procenti
+    latest: Kārtot pēc jaunākā
+    oldest: Kārtot pēc vecākā
+    set: Administratora iestatījums
+    syntax: |
+        &9 [date]
+        &9 [time]
+        &7 [name]
+        &6 [number]
+    take: Administratora noņemšana
+    title: Konta vēsture
+    unknown: Nezināms tips
+    withdrawal: Izņemšana
+  user:
+    description: salas bankas komanda
+  withdraw:
+    description: izņemt summu no jūsu salas konta
+    parameters: "<amount>"
+    success: "&a Veiksmīgi! Jūsu jaunais salas bankas atlikums ir [number]."
+    alert: "&a [name] izņēma [number] no salas bankas."
+protection:
+  flags:
+    BANK_ACCESS:
+      description: |-
+          &f Atļaut piekļuvi
+          &f salas bankai
+      name: Piekļuve salas bankai

--- a/src/main/resources/locales/nl.yml
+++ b/src/main/resources/locales/nl.yml
@@ -1,0 +1,81 @@
+---
+bank:
+  admin:
+    description: admin-commando voor de eilandbank
+    give:
+      parameters: "<player> <amount>"
+      description: voeg bedrag toe aan de eilandrekening van de speler
+      success: "&a Succes! Het eilandbanksaldo van [name] is nu [number]."
+    take:
+      parameters: "<player> <amount>"
+      description: neem bedrag van de eilandrekening van de speler
+    balance:
+      parameters: "<player>"
+      description: bekijk het saldo van de eilandrekening van de speler
+    set:
+      parameters: "<player> <amount>"
+      description: stel bedrag in op de eilandrekening van de speler
+      success: "&a Rekening van [name] ingesteld op [number]."
+    statement:
+      parameters: "<player>"
+      description: bekijk het eilandbankafschrift van de speler
+  balance:
+    description: toont je eilandbanksaldo
+    island-balance: "&a Eilandbanksaldo is [number]."
+  baltop:
+    description: toon saldoranglijst
+    description-syntax: "&d [number]"
+    highest: Sorteer op hoogste
+    lowest: Sorteer op laagste
+    name-syntax: "&d [name]"
+    title: Hoogste saldi
+  deposit:
+    description: stort bedrag op je eilandrekening
+    parameters: "<amount>"
+    success: "&a Succes! Je nieuwe eilandbanksaldo is [number]."
+    alert: "&a [name] heeft [number] op de eilandbank gestort."
+  errors:
+    bank-error: "&c Fout bij het laden van bankrekeninggegevens - probeer het later
+      opnieuw"
+    low-balance: "&c Je eilandbanksaldo is niet hoog genoeg!"
+    too-low: "&c Het eilandsaldo is te laag."
+    must-be-a-number: "&c Bedrag moet een getal zijn"
+    no-rank: "&c Je rang is niet hoog genoeg om de bank te gebruiken."
+    too-much: "&c Je hebt dat bedrag niet om te storten."
+    value-must-be-positive: "&c Bedrag moet positief zijn."
+    scientific: "&c Wetenschappelijke notatie wordt niet ondersteund."
+    too-long: "&c Waarde moet minder dan 10 cijfers hebben"
+  statement:
+    balance:
+      name: "&9 Saldo:"
+      description: "&6 [number]"
+    deposit: Storting
+    description: toon je eilandbankgeschiedenis
+    give: Admin geven
+    interest: Rente
+    latest: Sorteer op nieuwste
+    oldest: Sorteer op oudste
+    set: Admin instellen
+    syntax: |
+        &9 [date]
+        &9 [time]
+        &7 [name]
+        &6 [number]
+    take: Admin afnemen
+    title: Rekeninggeschiedenis
+    unknown: Onbekend type
+    withdrawal: Opname
+  user:
+    description: eilandbankcommando
+  withdraw:
+    description: neem bedrag op van je eilandrekening
+    parameters: "<amount>"
+    success: "&a Succes! Je nieuwe eilandbanksaldo is [number]."
+    alert: "&a [name] heeft [number] van de eilandbank opgenomen."
+protection:
+  flags:
+    BANK_ACCESS:
+      description: |-
+          &f Sta toegang toe tot
+          &f de eilandbank
+      name: Toegang tot eilandbank

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -1,0 +1,81 @@
+---
+bank:
+  admin:
+    description: komenda administratora dla banku wyspy
+    give:
+      parameters: "<player> <amount>"
+      description: dodaj kwotę do konta wyspy gracza
+      success: "&a Sukces! Saldo banku wyspy gracza [name] wynosi teraz [number]."
+    take:
+      parameters: "<player> <amount>"
+      description: zabierz kwotę z konta wyspy gracza
+    balance:
+      parameters: "<player>"
+      description: zobacz saldo konta wyspy gracza
+    set:
+      parameters: "<player> <amount>"
+      description: ustaw kwotę na koncie wyspy gracza
+      success: "&a Konto gracza [name] ustawione na [number]."
+    statement:
+      parameters: "<player>"
+      description: zobacz wyciąg z banku wyspy gracza
+  balance:
+    description: pokazuje saldo twojego banku wyspy
+    island-balance: "&a Saldo banku wyspy wynosi [number]."
+  baltop:
+    description: pokaż ranking sald
+    description-syntax: "&d [number]"
+    highest: Sortuj od najwyższego
+    lowest: Sortuj od najniższego
+    name-syntax: "&d [name]"
+    title: Najwyższe salda
+  deposit:
+    description: wpłać kwotę na konto swojej wyspy
+    parameters: "<amount>"
+    success: "&a Sukces! Twoje nowe saldo banku wyspy wynosi [number]."
+    alert: "&a [name] wpłacił [number] do banku wyspy."
+  errors:
+    bank-error: "&c Błąd podczas ładowania informacji o koncie bankowym - spróbuj
+      ponownie później"
+    low-balance: "&c Saldo twojego banku wyspy jest za niskie!"
+    too-low: "&c Saldo wyspy jest za niskie."
+    must-be-a-number: "&c Kwota musi być liczbą"
+    no-rank: "&c Twoja ranga nie jest wystarczająco wysoka, aby korzystać z banku."
+    too-much: "&c Nie masz takiej kwoty do wpłaty."
+    value-must-be-positive: "&c Kwota musi być dodatnia."
+    scientific: "&c Notacja naukowa nie jest obsługiwana."
+    too-long: "&c Wartość musi mieć mniej niż 10 cyfr"
+  statement:
+    balance:
+      name: "&9 Saldo:"
+      description: "&6 [number]"
+    deposit: Wpłata
+    description: pokaż historię twojego banku wyspy
+    give: Przyznanie administratora
+    interest: Odsetki
+    latest: Sortuj od najnowszych
+    oldest: Sortuj od najstarszych
+    set: Ustawienie administratora
+    syntax: |
+        &9 [date]
+        &9 [time]
+        &7 [name]
+        &6 [number]
+    take: Pobranie administratora
+    title: Historia konta
+    unknown: Nieznany typ
+    withdrawal: Wypłata
+  user:
+    description: komenda banku wyspy
+  withdraw:
+    description: wypłać kwotę z konta swojej wyspy
+    parameters: "<amount>"
+    success: "&a Sukces! Twoje nowe saldo banku wyspy wynosi [number]."
+    alert: "&a [name] wypłacił [number] z banku wyspy."
+protection:
+  flags:
+    BANK_ACCESS:
+      description: |-
+          &f Zezwól na dostęp do
+          &f banku wyspy
+      name: Dostęp do banku wyspy

--- a/src/main/resources/locales/pt-BR.yml
+++ b/src/main/resources/locales/pt-BR.yml
@@ -1,0 +1,81 @@
+---
+bank:
+  admin:
+    description: comando de admin para o banco da ilha
+    give:
+      parameters: "<player> <amount>"
+      description: adicionar quantia à conta da ilha do jogador
+      success: "&a Sucesso! O saldo do banco da ilha de [name] agora é [number]."
+    take:
+      parameters: "<player> <amount>"
+      description: retirar quantia da conta da ilha do jogador
+    balance:
+      parameters: "<player>"
+      description: ver o saldo da conta da ilha do jogador
+    set:
+      parameters: "<player> <amount>"
+      description: definir quantia na conta da ilha do jogador
+      success: "&a Conta de [name] definida para [number]."
+    statement:
+      parameters: "<player>"
+      description: ver o extrato do banco da ilha do jogador
+  balance:
+    description: mostra o saldo do banco da sua ilha
+    island-balance: "&a O saldo do banco da ilha é [number]."
+  baltop:
+    description: mostrar a classificação de saldos
+    description-syntax: "&d [number]"
+    highest: Ordenar do maior
+    lowest: Ordenar do menor
+    name-syntax: "&d [name]"
+    title: Maiores saldos
+  deposit:
+    description: depositar quantia na conta da sua ilha
+    parameters: "<amount>"
+    success: "&a Sucesso! O novo saldo do banco da sua ilha é [number]."
+    alert: "&a [name] depositou [number] no banco da ilha."
+  errors:
+    bank-error: "&c Erro ao carregar as informações da conta bancária - por favor
+      tente novamente mais tarde"
+    low-balance: "&c O saldo do banco da sua ilha não é alto o suficiente!"
+    too-low: "&c O saldo da ilha é muito baixo."
+    must-be-a-number: "&c A quantia deve ser um número"
+    no-rank: "&c Seu cargo não é alto o suficiente para usar o banco."
+    too-much: "&c Você não tem essa quantia para depositar."
+    value-must-be-positive: "&c A quantia deve ser positiva."
+    scientific: "&c Notação científica não é suportada."
+    too-long: "&c O valor deve ter menos de 10 dígitos"
+  statement:
+    balance:
+      name: "&9 Saldo:"
+      description: "&6 [number]"
+    deposit: Depósito
+    description: mostrar o histórico do banco da sua ilha
+    give: Dádiva do admin
+    interest: Juros
+    latest: Ordenar do mais recente
+    oldest: Ordenar do mais antigo
+    set: Definição do admin
+    syntax: |
+        &9 [date]
+        &9 [time]
+        &7 [name]
+        &6 [number]
+    take: Retirada do admin
+    title: Histórico da conta
+    unknown: Tipo desconhecido
+    withdrawal: Saque
+  user:
+    description: comando do banco da ilha
+  withdraw:
+    description: sacar quantia da conta da sua ilha
+    parameters: "<amount>"
+    success: "&a Sucesso! O novo saldo do banco da sua ilha é [number]."
+    alert: "&a [name] sacou [number] do banco da ilha."
+protection:
+  flags:
+    BANK_ACCESS:
+      description: |-
+          &f Permitir acesso ao
+          &f banco da ilha
+      name: Acesso ao banco da ilha

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -1,0 +1,81 @@
+---
+bank:
+  admin:
+    description: comando de administrador para o banco da ilha
+    give:
+      parameters: "<player> <amount>"
+      description: adicionar quantia à conta da ilha do jogador
+      success: "&a Sucesso! O saldo do banco da ilha de [name] é agora [number]."
+    take:
+      parameters: "<player> <amount>"
+      description: retirar quantia da conta da ilha do jogador
+    balance:
+      parameters: "<player>"
+      description: ver o saldo da conta da ilha do jogador
+    set:
+      parameters: "<player> <amount>"
+      description: definir quantia na conta da ilha do jogador
+      success: "&a Conta de [name] definida para [number]."
+    statement:
+      parameters: "<player>"
+      description: ver o extrato do banco da ilha do jogador
+  balance:
+    description: mostra o saldo do banco da tua ilha
+    island-balance: "&a O saldo do banco da ilha é [number]."
+  baltop:
+    description: mostrar a classificação de saldos
+    description-syntax: "&d [number]"
+    highest: Ordenar do mais alto
+    lowest: Ordenar do mais baixo
+    name-syntax: "&d [name]"
+    title: Maiores saldos
+  deposit:
+    description: depositar quantia na conta da tua ilha
+    parameters: "<amount>"
+    success: "&a Sucesso! O novo saldo do banco da tua ilha é [number]."
+    alert: "&a [name] depositou [number] no banco da ilha."
+  errors:
+    bank-error: "&c Erro ao carregar as informações da conta bancária - por favor
+      tenta novamente mais tarde"
+    low-balance: "&c O saldo do banco da tua ilha não é suficientemente alto!"
+    too-low: "&c O saldo da ilha é demasiado baixo."
+    must-be-a-number: "&c A quantia deve ser um número"
+    no-rank: "&c A tua categoria não é suficientemente alta para usar o banco."
+    too-much: "&c Não tens essa quantia para depositar."
+    value-must-be-positive: "&c A quantia deve ser positiva."
+    scientific: "&c Notação científica não é suportada."
+    too-long: "&c O valor deve ter menos de 10 dígitos"
+  statement:
+    balance:
+      name: "&9 Saldo:"
+      description: "&6 [number]"
+    deposit: Depósito
+    description: mostrar o histórico do banco da tua ilha
+    give: Dádiva do administrador
+    interest: Juros
+    latest: Ordenar do mais recente
+    oldest: Ordenar do mais antigo
+    set: Definição do administrador
+    syntax: |
+        &9 [date]
+        &9 [time]
+        &7 [name]
+        &6 [number]
+    take: Retirada do administrador
+    title: Histórico da conta
+    unknown: Tipo desconhecido
+    withdrawal: Levantamento
+  user:
+    description: comando do banco da ilha
+  withdraw:
+    description: levantar quantia da conta da tua ilha
+    parameters: "<amount>"
+    success: "&a Sucesso! O novo saldo do banco da tua ilha é [number]."
+    alert: "&a [name] levantou [number] do banco da ilha."
+protection:
+  flags:
+    BANK_ACCESS:
+      description: |-
+          &f Permitir acesso ao
+          &f banco da ilha
+      name: Acesso ao banco da ilha

--- a/src/main/resources/locales/ro.yml
+++ b/src/main/resources/locales/ro.yml
@@ -1,0 +1,81 @@
+---
+bank:
+  admin:
+    description: comandă de administrator pentru banca insulei
+    give:
+      parameters: "<player> <amount>"
+      description: adaugă sumă în contul de insulă al jucătorului
+      success: "&a Succes! Soldul băncii insulei lui [name] este acum [number]."
+    take:
+      parameters: "<player> <amount>"
+      description: ia sumă din contul de insulă al jucătorului
+    balance:
+      parameters: "<player>"
+      description: vezi soldul contului de insulă al jucătorului
+    set:
+      parameters: "<player> <amount>"
+      description: setează sumă în contul de insulă al jucătorului
+      success: "&a Contul lui [name] a fost setat la [number]."
+    statement:
+      parameters: "<player>"
+      description: vezi extrasul băncii insulei pentru jucător
+  balance:
+    description: arată soldul băncii insulei tale
+    island-balance: "&a Soldul băncii insulei este [number]."
+  baltop:
+    description: arată clasamentul soldurilor
+    description-syntax: "&d [number]"
+    highest: Sortează după cel mai mare
+    lowest: Sortează după cel mai mic
+    name-syntax: "&d [name]"
+    title: Cele mai mari solduri
+  deposit:
+    description: depune sumă în contul insulei tale
+    parameters: "<amount>"
+    success: "&a Succes! Noul tău sold al băncii insulei este [number]."
+    alert: "&a [name] a depus [number] în banca insulei."
+  errors:
+    bank-error: "&c Eroare la încărcarea informațiilor contului bancar - te rog
+      încearcă din nou mai târziu"
+    low-balance: "&c Soldul băncii insulei tale nu este suficient de mare!"
+    too-low: "&c Soldul insulei este prea mic."
+    must-be-a-number: "&c Suma trebuie să fie un număr"
+    no-rank: "&c Rangul tău nu este suficient de mare pentru a folosi banca."
+    too-much: "&c Nu ai această sumă pentru a o depune."
+    value-must-be-positive: "&c Suma trebuie să fie pozitivă."
+    scientific: "&c Notația științifică nu este acceptată."
+    too-long: "&c Valoarea trebuie să aibă mai puțin de 10 cifre"
+  statement:
+    balance:
+      name: "&9 Sold:"
+      description: "&6 [number]"
+    deposit: Depunere
+    description: arată istoricul băncii insulei tale
+    give: Acordare admin
+    interest: Dobândă
+    latest: Sortează după cele mai noi
+    oldest: Sortează după cele mai vechi
+    set: Setare admin
+    syntax: |
+        &9 [date]
+        &9 [time]
+        &7 [name]
+        &6 [number]
+    take: Retragere admin
+    title: Istoricul contului
+    unknown: Tip necunoscut
+    withdrawal: Retragere
+  user:
+    description: comanda băncii insulei
+  withdraw:
+    description: retrage sumă din contul insulei tale
+    parameters: "<amount>"
+    success: "&a Succes! Noul tău sold al băncii insulei este [number]."
+    alert: "&a [name] a retras [number] din banca insulei."
+protection:
+  flags:
+    BANK_ACCESS:
+      description: |-
+          &f Permite accesul la
+          &f banca insulei
+      name: Acces la banca insulei

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -1,0 +1,82 @@
+# ######################################################################################## #
+# Это YML файл. Будьте осторожны при редактировании. Проверяйте свои правки                #
+# в YAML валидаторе, например, на http://yaml-online-parser.appspot.com                    #
+# ######################################################################################## #
+
+bank:
+  admin:
+    description: административная команда островного банка
+    give:
+      parameters: <игрок> <сумма>
+      description: добавить сумму на счёт банка игрока
+      success: <green>Успешно! Баланс банка острова [name] теперь [number].</green>
+    take:
+      parameters: <игрок> <сумма>
+      description: снять сумму со счёта банка игрока
+    balance:
+      parameters: <игрок>
+      description: просмотреть баланс банка острова игрока
+    set:
+      parameters: <игрок> <сумма>
+      description: установить сумму на счёте банка игрока
+      success: <green>Счёт [name] установлен на [number].</green>
+    statement:
+      parameters: <игрок>
+      description: просмотреть выписку по банку острова игрока
+  balance:
+    description: показывает баланс вашего островного банка
+    island-balance: '<green>Баланс островного банка: [number].</green>'
+  baltop:
+    description: показать рейтинг балансов
+    description-syntax: <light_purple>[number]</light_purple>
+    highest: Сортировать по убыванию
+    lowest: Сортировать по возрастанию
+    name-syntax: <light_purple>[name]</light_purple>
+    title: Топ балансов
+  deposit:
+    description: внести сумму на счёт вашего острова
+    parameters: <сумма>
+    success: '<green>Успешно! Ваш новый баланс островного банка: [number].</green>'
+    alert: <green>[name] внёс [number] в островной банк.</green>
+  errors:
+    bank-error: <red>Ошибка загрузки информации о банковском счёте — попробуйте позже.</red>
+    low-balance: <red>Баланс вашего островного банка недостаточно высок!</red>
+    too-low: <red>Баланс острова слишком низкий.</red>
+    must-be-a-number: <red>Сумма должна быть числом.</red>
+    no-rank: <red>Ваш ранг недостаточно высок для использования банка.</red>
+    too-much: <red>У вас нет такой суммы для внесения.</red>
+    value-must-be-positive: <red>Сумма должна быть положительной.</red>
+    scientific: <red>Научная нотация не поддерживается.</red>
+    too-long: <red>Значение должно содержать менее 10 цифр.</red>
+  statement:
+    balance:
+      name: <blue>Баланс:</blue>
+      description: <gold>[number]</gold>
+    deposit: Внесение
+    description: показать историю вашего островного банка
+    give: Выдача администратором
+    interest: Проценты
+    latest: Сортировать по новизне
+    oldest: Сортировать по давности
+    set: Установка администратором
+    syntax: |-
+      <blue>[date]</blue>
+      <blue>[time]</blue>
+      <gray>[name]</gray>
+      <gold>[number]</gold>
+    take: Снятие администратором
+    title: История операций
+    unknown: Неизвестный тип
+    withdrawal: Снятие
+  user:
+    description: команда островного банка
+  withdraw:
+    description: снять сумму со счёта вашего острова
+    parameters: <сумма>
+    success: '<green>Успешно! Ваш новый баланс островного банка: [number].</green>'
+    alert: <green>[name] снял [number] с островного банка.</green>
+protection:
+  flags:
+    BANK_ACCESS:
+      description: Переключает доступ к островному банку
+      name: Доступ к островному банку

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -1,0 +1,81 @@
+---
+bank:
+  admin:
+    description: ada bankası için yönetici komutu
+    give:
+      parameters: "<player> <amount>"
+      description: oyuncunun ada hesabına miktar ekle
+      success: "&a Başarılı! [name] adlı oyuncunun ada banka bakiyesi şimdi [number]."
+    take:
+      parameters: "<player> <amount>"
+      description: oyuncunun ada hesabından miktar al
+    balance:
+      parameters: "<player>"
+      description: oyuncunun ada hesabının bakiyesini görüntüle
+    set:
+      parameters: "<player> <amount>"
+      description: oyuncunun ada hesabındaki miktarı ayarla
+      success: "&a [name] adlı oyuncunun hesabı [number] olarak ayarlandı."
+    statement:
+      parameters: "<player>"
+      description: oyuncunun ada banka ekstresini görüntüle
+  balance:
+    description: ada banka bakiyenizi gösterir
+    island-balance: "&a Ada banka bakiyesi [number]."
+  baltop:
+    description: bakiye sıralamasını göster
+    description-syntax: "&d [number]"
+    highest: En yüksekten sırala
+    lowest: En düşükten sırala
+    name-syntax: "&d [name]"
+    title: En yüksek bakiyeler
+  deposit:
+    description: ada hesabınıza miktar yatırın
+    parameters: "<amount>"
+    success: "&a Başarılı! Yeni ada banka bakiyeniz [number]."
+    alert: "&a [name] ada bankasına [number] yatırdı."
+  errors:
+    bank-error: "&c Banka hesabı bilgileri yüklenirken hata oluştu - lütfen daha
+      sonra tekrar deneyin"
+    low-balance: "&c Ada banka bakiyeniz yeterince yüksek değil!"
+    too-low: "&c Ada bakiyesi çok düşük."
+    must-be-a-number: "&c Miktar bir sayı olmalı"
+    no-rank: "&c Rütbeniz bankayı kullanmak için yeterince yüksek değil."
+    too-much: "&c Yatıracak o kadar miktarınız yok."
+    value-must-be-positive: "&c Miktar pozitif olmalı."
+    scientific: "&c Bilimsel gösterim desteklenmiyor."
+    too-long: "&c Değer 10 haneden az olmalı"
+  statement:
+    balance:
+      name: "&9 Bakiye:"
+      description: "&6 [number]"
+    deposit: Yatırma
+    description: ada banka geçmişinizi göster
+    give: Yönetici verme
+    interest: Faiz
+    latest: En yeniden sırala
+    oldest: En eskiden sırala
+    set: Yönetici ayarlama
+    syntax: |
+        &9 [date]
+        &9 [time]
+        &7 [name]
+        &6 [number]
+    take: Yönetici alma
+    title: Hesap geçmişi
+    unknown: Bilinmeyen tür
+    withdrawal: Çekme
+  user:
+    description: ada bankası komutu
+  withdraw:
+    description: ada hesabınızdan miktar çekin
+    parameters: "<amount>"
+    success: "&a Başarılı! Yeni ada banka bakiyeniz [number]."
+    alert: "&a [name] ada bankasından [number] çekti."
+protection:
+  flags:
+    BANK_ACCESS:
+      description: |-
+          &f Ada bankasına
+          &f erişime izin ver
+      name: Ada bankası erişimi

--- a/src/main/resources/locales/zh-HK.yml
+++ b/src/main/resources/locales/zh-HK.yml
@@ -1,0 +1,80 @@
+---
+bank:
+  admin:
+    description: 島嶼銀行的管理員指令
+    give:
+      parameters: "<player> <amount>"
+      description: 將金額加入玩家的島嶼帳戶
+      success: "&a 成功！[name] 的島嶼銀行餘額現在是 [number]。"
+    take:
+      parameters: "<player> <amount>"
+      description: 從玩家的島嶼帳戶扣除金額
+    balance:
+      parameters: "<player>"
+      description: 查看玩家島嶼帳戶的餘額
+    set:
+      parameters: "<player> <amount>"
+      description: 設定玩家島嶼帳戶的金額
+      success: "&a [name] 的帳戶已設定為 [number]。"
+    statement:
+      parameters: "<player>"
+      description: 查看玩家的島嶼銀行明細
+  balance:
+    description: 顯示你的島嶼銀行餘額
+    island-balance: "&a 島嶼銀行餘額是 [number]。"
+  baltop:
+    description: 顯示餘額排行榜
+    description-syntax: "&d [number]"
+    highest: 由高至低排序
+    lowest: 由低至高排序
+    name-syntax: "&d [name]"
+    title: 餘額排行榜
+  deposit:
+    description: 將金額存入你的島嶼帳戶
+    parameters: "<amount>"
+    success: "&a 成功！你新的島嶼銀行餘額是 [number]。"
+    alert: "&a [name] 存入了 [number] 到島嶼銀行。"
+  errors:
+    bank-error: "&c 載入銀行帳戶資料時發生錯誤 - 請稍後再試"
+    low-balance: "&c 你的島嶼銀行餘額不足！"
+    too-low: "&c 島嶼餘額太低。"
+    must-be-a-number: "&c 金額必須是數字"
+    no-rank: "&c 你的等級不足以使用銀行。"
+    too-much: "&c 你沒有那麼多金額可以存入。"
+    value-must-be-positive: "&c 金額必須為正數。"
+    scientific: "&c 不支援科學記數法。"
+    too-long: "&c 數值必須少於 10 位數"
+  statement:
+    balance:
+      name: "&9 餘額："
+      description: "&6 [number]"
+    deposit: 存款
+    description: 顯示你的島嶼銀行紀錄
+    give: 管理員給予
+    interest: 利息
+    latest: 由最新排序
+    oldest: 由最舊排序
+    set: 管理員設定
+    syntax: |
+        &9 [date]
+        &9 [time]
+        &7 [name]
+        &6 [number]
+    take: 管理員扣除
+    title: 帳戶紀錄
+    unknown: 未知類型
+    withdrawal: 提款
+  user:
+    description: 島嶼銀行指令
+  withdraw:
+    description: 從你的島嶼帳戶提取金額
+    parameters: "<amount>"
+    success: "&a 成功！你新的島嶼銀行餘額是 [number]。"
+    alert: "&a [name] 從島嶼銀行提取了 [number]。"
+protection:
+  flags:
+    BANK_ACCESS:
+      description: |-
+          &f 允許存取
+          &f 島嶼銀行
+      name: 島嶼銀行存取


### PR DESCRIPTION
## Summary

- Incorporates the Russian translation from #62 as `ru.yml` (complete, matched the en-US key structure exactly).
- Syncs the two newer `alert` keys (`bank.deposit.alert`, `bank.withdraw.alert`, added in #61) into the existing `cs`, `de`, and `ja` files, which were missing them.
- Adds the 10 languages BentoBox supports that Bank was missing, fully translated against en-US: `hr`, `hu`, `lv`, `nl`, `pl`, `pt-BR`, `pt`, `ro`, `tr`, `zh-HK`.

Bank's locale set now exactly matches BentoBox's 23-language set.

## Verification

- All 23 locale files parse as valid YAML.
- Every file is in sync with `en-US.yml` (55 keys each, 0 missing / 0 extra).
- Color codes (`&a`/`&c`/`&9`/`&6`/`&d`/`&f`), placeholders (`[name]`, `[number]`, `[date]`, `[time]`), command syntax (`<player>`, `<amount>`), and block scalars preserved throughout.
- `mvn clean package` builds the JAR cleanly.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)