### PR TITLE
Convert locale color codes to MiniMessage format

### DIFF
--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<hráč> <množství>"
       description: přidat částku na hráčův ostrovní účet
-      success: "&a Úspěch! Zůstatek ostrovní banky [name] je nyní [number]."
+      success: "<green> Úspěch! Zůstatek ostrovní banky [name] je nyní [number]."
     take:
       parameters: "<hráč> <množství>"
       description: vezměte částku z hráčova ostrova
@@ -15,39 +15,39 @@ bank:
     set:
       parameters: "<hráč> <množství>"
       description: nastavit částku na hráčově ostrovním účtu
-      success: "&a Účet uživatele [name] byl nastaven na [number]."
+      success: "<green> Účet uživatele [name] byl nastaven na [number]."
     statement:
       parameters: "<hráč>"
       description: zobrazit výpis z banky pro hráče
   balance:
     description: ukazuje zůstatek vaší ostrovní banky
-    island-balance: "&a Zůstatek na ostrovní bance je [number]."
+    island-balance: "<green> Zůstatek na ostrovní bance je [number]."
   baltop:
     description: zobrazit hodnocení zůstatku
-    description-syntax: "&d [number]"
+    description-syntax: "<light_purple> [number]"
     highest: Řadit podle nejvyššího
     lowest: Řadit podle nejnižší
-    name-syntax: "&d [name]"
+    name-syntax: "<light_purple> [name]"
     title: Nejlepší zůstatky
   deposit:
     description: vložte částku na svůj ostrovní účet
     parameters: "<množství>"
-    success: "&a Úspěch! Váš nový zůstatek na ostrovní bance je [number]."
+    success: "<green> Úspěch! Váš nový zůstatek na ostrovní bance je [number]."
   errors:
-    bank-error: "&c Chyba při načítání informací o bankovním účtu - zkuste to znovu
+    bank-error: "<red> Chyba při načítání informací o bankovním účtu - zkuste to znovu
       později"
-    low-balance: "&c Váš zůstatek na ostrovní bance není dostatečně vysoký!"
-    too-low: "&c Rovnováha na ostrově je příliš nízká."
-    must-be-a-number: "&c Částka musí být číslo"
-    no-rank: "&c Vaše pozice není dostatečně vysoká, abyste mohli banku používat."
-    too-much: "&c Tuto částku nemáte k uložení."
-    value-must-be-positive: "&c Částka musí být kladná."
-    scientific: "&c Vědecká notace není podporována."
-    too-long: "&c Hodnota musí být menší než 10 číslic"
+    low-balance: "<red> Váš zůstatek na ostrovní bance není dostatečně vysoký!"
+    too-low: "<red> Rovnováha na ostrově je příliš nízká."
+    must-be-a-number: "<red> Částka musí být číslo"
+    no-rank: "<red> Vaše pozice není dostatečně vysoká, abyste mohli banku používat."
+    too-much: "<red> Tuto částku nemáte k uložení."
+    value-must-be-positive: "<red> Částka musí být kladná."
+    scientific: "<red> Vědecká notace není podporována."
+    too-long: "<red> Hodnota musí být menší než 10 číslic"
   statement:
     balance:
-      name: "&9 Zůstatek:"
-      description: "&6 [number]"
+      name: "<blue> Zůstatek:"
+      description: "<gold> [number]"
     deposit: Vklad
     description: ukažte historii své ostrovní banky
     give: Správce dát
@@ -56,10 +56,10 @@ bank:
     oldest: Řadit podle nejstarších
     set: Sada správce
     syntax: |-
-      &9 [date]
-      &9 [time]
-      &7 [name]
-      &6 [number]
+      <blue> [date]
+      <blue> [time]
+      <gray> [name]
+      <gold> [number]
     take: Admin Vezměte
     title: Historie účtu
     unknown: Neznámý typ
@@ -69,11 +69,11 @@ bank:
   withdraw:
     description: vybrat částku ze svého ostrovního účtu
     parameters: "<množství>"
-    success: "&a Úspěch! Váš nový zůstatek na ostrovní bance je [number]."
+    success: "<green> Úspěch! Váš nový zůstatek na ostrovní bance je [number]."
 protection:
   flags:
     BANK_ACCESS:
       description: |-
-        &f Povolit přístup k
-        &f a ostrovní banka
+        <white> Povolit přístup k
+        <white> a ostrovní banka
       name: Přístup na ostrovní banku

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<player> <amount>"
       description: Betrag zum Inselkonto des Spielers hinzufügen
-      success: "&a Erfolgreich! [name]'s Insel Bank Balance ist nun [number]."
+      success: "<green> Erfolgreich! [name]'s Insel Bank Balance ist nun [number]."
     take:
       parameters: "<player> <amount>"
       description: Betrag vom Inselkonto des Spielers nehmen
@@ -15,39 +15,39 @@ bank:
     set:
       parameters: "<player> <amount>"
       description: festgelegten Betrag auf dem Inselkonto des Spielers
-      success: "&a [name]'s Konto auf [number] gesetzt."
+      success: "<green> [name]'s Konto auf [number] gesetzt."
     statement:
       parameters: "<player>"
       description: Kontoauszug der Insel für den Spieler anzeigen
   balance:
     description: zeigt Ihren Kontostand auf der Insel an
-    island-balance: "&a Bankguthaben auf der Insel ist [number]."
+    island-balance: "<green> Bankguthaben auf der Insel ist [number]."
   baltop:
     description: Balance-Rankings anzeigen
-    description-syntax: "&d [number]"
+    description-syntax: "<light_purple> [number]"
     highest: Nach Höchsten sortieren
     lowest: Nach Niedrigster sortieren
-    name-syntax: "&d [name]"
+    name-syntax: "<light_purple> [name]"
     title: Top-Balancen
   deposit:
     description: Betrag auf Ihr Inselkonto einzahlen
     parameters: "<amount>"
-    success: "&ein Erfolg! Ihr neuer Kontostand auf der Insel beträgt [number]."
+    success: "<yellow>in Erfolg! Ihr neuer Kontostand auf der Insel beträgt [number]."
   errors:
-    bank-error: "&c Fehler beim Laden der Bankkontoinformationen - bitte versuchen
+    bank-error: "<red> Fehler beim Laden der Bankkontoinformationen - bitte versuchen
       Sie es später erneut"
-    low-balance: "&c Ihr Bankguthaben auf der Insel ist nicht hoch genug!"
-    too-low: "&c Der Insel Geld ist zu niedrig."
-    must-be-a-number: "&c Betrag muss eine Zahl sein"
-    no-rank: "&c Ihr Rang ist nicht hoch genug, um die Bank zu benutzen."
-    too-much: "&c Sie haben nicht genug Geld zum einzahlen."
-    value-must-be-positive: "&c Betrag muss positiv sein."
-    scientific: "&c Wissenschaftliche Notation wird nicht unterstützt."
-    too-long: "&c Wert muss kleiner als 10 Stellen sein"
+    low-balance: "<red> Ihr Bankguthaben auf der Insel ist nicht hoch genug!"
+    too-low: "<red> Der Insel Geld ist zu niedrig."
+    must-be-a-number: "<red> Betrag muss eine Zahl sein"
+    no-rank: "<red> Ihr Rang ist nicht hoch genug, um die Bank zu benutzen."
+    too-much: "<red> Sie haben nicht genug Geld zum einzahlen."
+    value-must-be-positive: "<red> Betrag muss positiv sein."
+    scientific: "<red> Wissenschaftliche Notation wird nicht unterstützt."
+    too-long: "<red> Wert muss kleiner als 10 Stellen sein"
   statement:
     balance:
-      name: "&9 Balance:"
-      description: "&6 [number]"
+      name: "<blue> Balance:"
+      description: "<gold> [number]"
     deposit: Einzahlen
     description: Zeigen Sie Ihre Inselbankgeschichte
     give: Admin gibt
@@ -56,10 +56,10 @@ bank:
     oldest: Nach Ältesten sortieren
     set: Admin-Setzt
     syntax: |
-      &9 [date]
-      &9 [time]
-      &7 [name]
-      &6 [number]
+      <blue> [date]
+      <blue> [time]
+      <gray> [name]
+      <gold> [number]
     take: Admin-nimmt
     title: Kontoverlauf
     unknown: Unbekannter Typ
@@ -69,11 +69,11 @@ bank:
   withdraw:
     description: Betrag von Ihrem Inselkonto abheben
     parameters: "<amount>"
-    success: "&ein Erfolg! Ihr neuer Kontostand auf der Insel beträgt [number]."
+    success: "<yellow>in Erfolg! Ihr neuer Kontostand auf der Insel beträgt [number]."
 protection:
   flags:
     BANK_ACCESS:
       description: |-
-        &f Zugriff erlauben auf
-        &f das Inselufer
+        <white> Zugriff erlauben auf
+        <white> das Inselufer
       name: Zugriff zur Inselbank

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -4,7 +4,7 @@ bank:
     give:
       parameters: "<player> <amount>"
       description: "add amount to player's island account"
-      success: "&a Success! [name]'s island bank balance is now [number]."
+      success: "<green> Success! [name]'s island bank balance is now [number]."
     take:
       parameters: "<player> <amount>"
       description: "take amount from player's island account"
@@ -14,39 +14,39 @@ bank:
     set:
       parameters: "<player> <amount>"
       description: "set amount in player's island account"
-      success: "&a [name]'s account set to [number]."
+      success: "<green> [name]'s account set to [number]."
     statement:
       parameters: "<player>"
       description: "view island bank statement for player"
   balance: 
     description: "shows your island bank balance"
-    island-balance: "&a Island bank balance is [number]."
+    island-balance: "<green> Island bank balance is [number]."
   baltop: 
     description: "show balance rankings"
-    description-syntax: "&d [number]"
+    description-syntax: "<light_purple> [number]"
     highest: "Sort by Highest"
     lowest: "Sort by Lowest"
-    name-syntax: "&d [name]"
+    name-syntax: "<light_purple> [name]"
     title: "Top Balances"
   deposit: 
     description: "deposit amount into your island account"
     parameters: <amount>
-    success: "&a Success! Your new island bank balance is [number]."
-    alert: '&a [name] deposited [number] into the island bank.'
+    success: "<green> Success! Your new island bank balance is [number]."
+    alert: '<green> [name] deposited [number] into the island bank.'
   errors: 
-    bank-error: "&c Error loading bank account info - please try again later"
-    low-balance: "&c Your island bank balance is not high enough!"
-    too-low: "&c The island balance is too low."
-    must-be-a-number: "&c Amount must be a number"
-    no-rank: "&c Your rank is not high enough to use the bank."
-    too-much: "&c You do not have that amount to deposit."
-    value-must-be-positive: "&c Amount must be positive."
-    scientific: "&c Scientific notation is not supported."
-    too-long: "&c Value must be less than 10 digits"
+    bank-error: "<red> Error loading bank account info - please try again later"
+    low-balance: "<red> Your island bank balance is not high enough!"
+    too-low: "<red> The island balance is too low."
+    must-be-a-number: "<red> Amount must be a number"
+    no-rank: "<red> Your rank is not high enough to use the bank."
+    too-much: "<red> You do not have that amount to deposit."
+    value-must-be-positive: "<red> Amount must be positive."
+    scientific: "<red> Scientific notation is not supported."
+    too-long: "<red> Value must be less than 10 digits"
   statement:
     balance:
-      name: "&9 Balance:"
-      description: "&6 [number]"
+      name: "<blue> Balance:"
+      description: "<gold> [number]"
     deposit: Deposit
     description: "show your island bank history"
     give: "Admin Give"
@@ -55,10 +55,10 @@ bank:
     oldest: "Sort by oldest"
     set: "Admin Set"
     syntax: |
-        &9 [date]
-        &9 [time]
-        &7 [name]
-        &6 [number]
+        <blue> [date]
+        <blue> [time]
+        <gray> [name]
+        <gold> [number]
     take: "Admin Take"
     title: "Account history"
     unknown: "Unknown Type"
@@ -68,12 +68,12 @@ bank:
   withdraw: 
     description: "withdraw amount from your island account"
     parameters: <amount>
-    success: "&a Success! Your new island bank balance is [number]."
-    alert: '&a [name] withdrew [number] from the island bank.'
+    success: "<green> Success! Your new island bank balance is [number]."
+    alert: '<green> [name] withdrew [number] from the island bank.'
 protection: 
   flags: 
     BANK_ACCESS: 
       description: |-
-          &f Allow acces to
-          &f the island bank
+          <white> Allow acces to
+          <white> the island bank
       name: "Island Bank Access"

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<jugador> <cantidad>"
       description: agrega cierta cantidad a la cuenta de la isla del jugador
-      success: "&a ¡Éxito! El saldo del banco de la isla de [name] ahora es [number]."
+      success: "<green> ¡Éxito! El saldo del banco de la isla de [name] ahora es [number]."
     take:
       parameters: "<jugador> <cantidad>"
       description: quita cierta cantidad a la cuenta de la isla del jugador
@@ -15,16 +15,16 @@ bank:
     set:
       parameters: "<jugador> <cantidad>"
       description: establece la cuenta de la isla del jugador a cierta cantidad
-      success: "&a La cuenta de la isla de [name] fue establecida a [number]."
+      success: "<green> La cuenta de la isla de [name] fue establecida a [number]."
     statement:
       parameters: "<jugador>"
       description: ver extracto bancario de la isla para el jugador
   balance:
     description: muestra el saldo bancario de su isla
-    island-balance: "&a Saldo del banco de la isla es [number]."
+    island-balance: "<green> Saldo del banco de la isla es [number]."
   baltop:
     description: mostrar clasificaciones de equilibrio
-    description-syntax: "&d [number]"
+    description-syntax: "<light_purple> [number]"
     highest: Ordenar por más alto
     lowest: Ordenar por el más bajo
     name-syntax: "& d [name]"
@@ -32,23 +32,23 @@ bank:
   deposit:
     description: depositar cantidad en su cuenta de la isla
     parameters: "<cantidad>"
-    success: "&a ¡Éxito! Su nuevo saldo en el banco de la isla es [number]."
-    alert: "&a [name] ha depositado [number] en el banco de la isla."
+    success: "<green> ¡Éxito! Su nuevo saldo en el banco de la isla es [number]."
+    alert: "<green> [name] ha depositado [number] en el banco de la isla."
   errors:
-    bank-error: "&c Error al cargar la información de la cuenta bancaria. Vuelve a
+    bank-error: "<red> Error al cargar la información de la cuenta bancaria. Vuelve a
       intentarlo más tarde."
-    low-balance: "&c ¡El saldo del banco de su isla no es lo suficientemente alto!"
-    too-low: "&c El saldo de la isla es demasiado bajo."
-    must-be-a-number: "&c La cantidad debe ser un número"
-    no-rank: "&c Tu rango no es lo suficientemente alto para usar el banco."
-    too-much: "&c No tiene esa cantidad para depositar."
-    value-must-be-positive: "&c La cantidad debe ser positiva."
-    scientific: "&c No se admite la notación científica."
-    too-long: "&c El valor debe tener menos de 10 dígitos"
+    low-balance: "<red> ¡El saldo del banco de su isla no es lo suficientemente alto!"
+    too-low: "<red> El saldo de la isla es demasiado bajo."
+    must-be-a-number: "<red> La cantidad debe ser un número"
+    no-rank: "<red> Tu rango no es lo suficientemente alto para usar el banco."
+    too-much: "<red> No tiene esa cantidad para depositar."
+    value-must-be-positive: "<red> La cantidad debe ser positiva."
+    scientific: "<red> No se admite la notación científica."
+    too-long: "<red> El valor debe tener menos de 10 dígitos"
   statement:
     balance:
       name: "& 9 Equilibrio:"
-      description: "&6 [number]"
+      description: "<gold> [number]"
     deposit: Depositar
     description: muestra el historial de tu banco de la isla
     give: Admin Dar
@@ -57,10 +57,10 @@ bank:
     oldest: Ordenar por más antiguo
     set: Admin Establecer
     syntax: |
-      &9 [date]
-      &9 [time]
-      &7 [name]
-      &6 [number]
+      <blue> [date]
+      <blue> [time]
+      <gray> [name]
+      <gold> [number]
     take: Admin Tomar
     title: Historial de cuenta
     unknown: Tipo desconocido
@@ -70,12 +70,12 @@ bank:
   withdraw:
     description: retirar cantidad de su cuenta de la isla
     parameters: "<cantidad>"
-    success: "&a ¡Éxito! Su nuevo saldo en el banco de la isla es [number]."
-    alert: "&a [name] ha depositado [number] en el banco de la isla."
+    success: "<green> ¡Éxito! Su nuevo saldo en el banco de la isla es [number]."
+    alert: "<green> [name] ha depositado [number] en el banco de la isla."
 protection:
   flags:
     BANK_ACCESS:
       description: |-
-        &f Permitir el acceso
-        &f al banco de la isla
+        <white> Permitir el acceso
+        <white> al banco de la isla
       name: Acceso al banco de la isla

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<joueur> <montant>"
       description: ajouter un montant au compte de l'île du joueur
-      success: "&a Succès! Le solde bancaire de l'île de [name] est désormais de [number]."
+      success: "<green> Succès! Le solde bancaire de l'île de [name] est désormais de [number]."
     take:
       parameters: "<joueur> <montant>"
       description: prendre le montant du compte de l'île du joueur
@@ -15,40 +15,40 @@ bank:
     set:
       parameters: "<joueur> <montant>"
       description: définir le montant sur le compte de l'île du joueur
-      success: "&a compte de [name] défini sur [number]."
+      success: "<green> compte de [name] défini sur [number]."
     statement:
       parameters: "<joueur>"
       description: voir le relevé bancaire de l'île pour le joueur
   balance:
     description: affiche le solde bancaire de votre île
-    island-balance: "&a solde bancaire de l'île est [number]."
+    island-balance: "<green> solde bancaire de l'île est [number]."
   baltop:
     description: afficher les classements d'équilibre
-    description-syntax: "&d[number]"
+    description-syntax: "<light_purple>[number]"
     highest: Trier par le plus élevé
     lowest: Trier par le plus bas
-    name-syntax: "&d [name]"
+    name-syntax: "<light_purple> [name]"
     title: Principaux soldes
   deposit:
     description: déposer le montant sur votre compte insulaire
     parameters: "<montant>"
-    success: "&a Succès! Le nouveau solde bancaire de votre île est de [number]."
-    alert: "&a [name] a déposé [number] à la banque de l'île."
+    success: "<green> Succès! Le nouveau solde bancaire de votre île est de [number]."
+    alert: "<green> [name] a déposé [number] à la banque de l'île."
   errors:
-    bank-error: "&c Erreur lors du chargement des informations du compte bancaire
+    bank-error: "<red> Erreur lors du chargement des informations du compte bancaire
       - veuillez réessayer plus tard"
-    low-balance: "&c Le solde bancaire de votre île n'est pas assez élevé!"
-    too-low: "&c L'équilibre de l'île est trop faible."
-    must-be-a-number: "&c Le montant doit être un nombre"
-    no-rank: "&c Votre rang n'est pas assez élevé pour utiliser la banque."
-    too-much: "&c Vous n'avez pas ce montant à déposer."
-    value-must-be-positive: "&c Le montant doit être positif."
-    scientific: "&c La notation scientifique n'est pas prise en charge."
-    too-long: "&c La valeur doit être inférieure à 10 chiffres"
+    low-balance: "<red> Le solde bancaire de votre île n'est pas assez élevé!"
+    too-low: "<red> L'équilibre de l'île est trop faible."
+    must-be-a-number: "<red> Le montant doit être un nombre"
+    no-rank: "<red> Votre rang n'est pas assez élevé pour utiliser la banque."
+    too-much: "<red> Vous n'avez pas ce montant à déposer."
+    value-must-be-positive: "<red> Le montant doit être positif."
+    scientific: "<red> La notation scientifique n'est pas prise en charge."
+    too-long: "<red> La valeur doit être inférieure à 10 chiffres"
   statement:
     balance:
-      name: "&9 Le solde :"
-      description: "&6 [number]"
+      name: "<blue> Le solde :"
+      description: "<gold> [number]"
     deposit: Dépôt
     description: montrer l'histoire de votre banque insulaire
     give: Admin Donner
@@ -57,10 +57,10 @@ bank:
     oldest: Trier par plus ancien
     set: Admin Valeur Définir
     syntax: |
-      &9 [date]
-      &9 [time]
-      &7 [name]
-      &6 [number]
+      <blue> [date]
+      <blue> [time]
+      <gray> [name]
+      <gold> [number]
     take: Admin Prend
     title: Historique du compte
     unknown: Type inconnu
@@ -70,12 +70,12 @@ bank:
   withdraw:
     description: retirer le montant de votre compte insulaire
     parameters: "<montant>"
-    success: "&a Succès! Le nouveau solde bancaire de votre île est de [number]."
-    alert: "&a [name] a retiré [number] de la banque de l'île."
+    success: "<green> Succès! Le nouveau solde bancaire de votre île est de [number]."
+    alert: "<green> [name] a retiré [number] de la banque de l'île."
 protection:
   flags:
     BANK_ACCESS:
       description: |-
-        &f Autoriser l'accès à
-        &f la rive de l'île
+        <white> Autoriser l'accès à
+        <white> la rive de l'île
       name: Accès à la banque de l'île

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<player> <amount>"
       description: menambah jumlah saldo ke rekening pulau pemain
-      success: "&a Sukses! Saldo bank pulau [name] sekarang [number]."
+      success: "<green> Sukses! Saldo bank pulau [name] sekarang [number]."
     take:
       parameters: "<player> <amount>"
       description: mengambil jumlah saldo dari rekening pulau pemain
@@ -15,39 +15,39 @@ bank:
     set:
       parameters: "<player> <amount>"
       description: mengatur jumlah saldo di rekening pulau pemain
-      success: "&a Rekening [name] diatur menjadi [number]."
+      success: "<green> Rekening [name] diatur menjadi [number]."
     statement:
       parameters: "<player>"
       description: melihat rekening koran pulau untuk pemain
   balance:
     description: menunjukkan saldo bank pulau kamu
-    island-balance: "&a Saldo bank pulau adalah [number]."
+    island-balance: "<green> Saldo bank pulau adalah [number]."
   baltop:
     description: menunjukkan peringkat saldo
-    description-syntax: "&d [number]"
+    description-syntax: "<light_purple> [number]"
     highest: Urutkan dari Tertinggi
     lowest: Urutkan dari Terendah
-    name-syntax: "&d [name]"
+    name-syntax: "<light_purple> [name]"
     title: Saldo Teratas
   deposit:
     description: menyetor jumlah saldo ke rekening pulau kamu
     parameters: "<amount>"
-    success: "&a Sukses! Saldo bank pulau kamu yang baru adalah [number]."
-    alert: "&a [name] menyetor [number] ke bank pulau."
+    success: "<green> Sukses! Saldo bank pulau kamu yang baru adalah [number]."
+    alert: "<green> [name] menyetor [number] ke bank pulau."
   errors:
-    bank-error: "&c Kesalahan memuat info rekening bank - silahkan coba lagi nanti"
-    low-balance: "&c Saldo bank pulau kamu tidak cukup tinggi!"
-    too-low: "&c Saldo pulau terlalu rendah."
-    must-be-a-number: "&c Jumlah harus berupa angka"
-    no-rank: "&c Rank kamu tidak cukup tinggi untuk menggunakan bank."
-    too-much: "&c Kamu tidak punya jumlah tersebut untuk disetor."
-    value-must-be-positive: "&c Jumlah harus positif."
-    scientific: "&c Notasi ilmiah tidak didukung."
-    too-long: "&c Nilai harus kurang dari 10 digit"
+    bank-error: "<red> Kesalahan memuat info rekening bank - silahkan coba lagi nanti"
+    low-balance: "<red> Saldo bank pulau kamu tidak cukup tinggi!"
+    too-low: "<red> Saldo pulau terlalu rendah."
+    must-be-a-number: "<red> Jumlah harus berupa angka"
+    no-rank: "<red> Rank kamu tidak cukup tinggi untuk menggunakan bank."
+    too-much: "<red> Kamu tidak punya jumlah tersebut untuk disetor."
+    value-must-be-positive: "<red> Jumlah harus positif."
+    scientific: "<red> Notasi ilmiah tidak didukung."
+    too-long: "<red> Nilai harus kurang dari 10 digit"
   statement:
     balance:
-      name: "&9 Saldo:"
-      description: "&6 [number]"
+      name: "<blue> Saldo:"
+      description: "<gold> [number]"
     deposit: Setor
     description: menunjukkan sejarah bank pulau kamu
     give: Admin Memberi
@@ -56,10 +56,10 @@ bank:
     oldest: Urut dari terlama
     set: Admin Mengubah
     syntax: |
-      &9 [date]
-      &9 [time]
-      &7 [name]
-      &6 [number]
+      <blue> [date]
+      <blue> [time]
+      <gray> [name]
+      <gold> [number]
     take: Admin Mengambil
     title: Sejarah rekening
     unknown: Tipe Tidak Diketahui
@@ -69,12 +69,12 @@ bank:
   withdraw:
     description: menarik jumlah saldo dari rekening pulau kamu
     parameters: "<amount>"
-    success: "&a Sukses! Saldo bank pulau kamu yang baru adalah [number]."
-    alert: "&a [name] menarik [number] dari bank pulau."
+    success: "<green> Sukses! Saldo bank pulau kamu yang baru adalah [number]."
+    alert: "<green> [name] menarik [number] dari bank pulau."
 protection:
   flags:
     BANK_ACCESS:
       description: |-
-        &f Mengizinkan akses ke
-        &f bank pulau
+        <white> Mengizinkan akses ke
+        <white> bank pulau
       name: Akses Bank Pulau

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<giocatore> <importo>"
       description: aggiungi importo al conto dell'isola del giocatore
-      success: "&aFatto! Il saldo bancario dell'isola di [nome] è ora [numero]."
+      success: "<green>Fatto! Il saldo bancario dell'isola di [nome] è ora [numero]."
     take:
       parameters: "<giocatore> <importo>"
       description: preleva l'importo dal conto dell'isola del giocatore
@@ -15,40 +15,40 @@ bank:
     set:
       parameters: "<giocatore> <importo>"
       description: imposta l'importo nel conto dell'isola del giocatore
-      success: "&aIl bilancio di [name] è stato impostato su [number]."
+      success: "<green>Il bilancio di [name] è stato impostato su [number]."
     statement:
       parameters: "<giocatore>"
       description: visualizza l'estratto conto dell'isola per il giocatore
   balance:
     description: mostra il bilancio della tua isola
-    island-balance: "&aIl bilancio dell'isola è [number]."
+    island-balance: "<green>Il bilancio dell'isola è [number]."
   baltop:
     description: mostra la classifica dei bilanci
-    description-syntax: "&d [number]"
+    description-syntax: "<light_purple> [number]"
     highest: Ordina per più alto
     lowest: Ordina per più basso
-    name-syntax: "&d [name]"
+    name-syntax: "<light_purple> [name]"
     title: I bilanci più alti
   deposit:
     description: deposita l'importo nella banca dell'isola
     parameters: "<importo>"
-    success: "&Fatto! Il tuo nuovo saldo bancario sull'isola è [number]."
-    alert: "&a[name] ha depositato [number] nella banca dell'isola."
+    success: "<white>atto! Il tuo nuovo saldo bancario sull'isola è [number]."
+    alert: "<green>[name] ha depositato [number] nella banca dell'isola."
   errors:
-    bank-error: "&c Errore durante il caricamento dei dati del conto bancario: riprova
+    bank-error: "<red> Errore durante il caricamento dei dati del conto bancario: riprova
       più tardi"
-    low-balance: "&c Il saldo della tua isola non è abbastanza alto!"
-    too-low: "&c Il saldo dell'isola è troppo basso."
-    must-be-a-number: "&c L'importo deve essere un numero"
-    no-rank: "&c Il tuo grado non è sufficientemente alto per utilizzare la banca."
-    too-much: "&c Non hai quell'importo da depositare."
-    value-must-be-positive: "&c L'importo deve essere positivo."
-    scientific: "&c La notazione scientifica non è supportata."
-    too-long: "&c Il valore deve essere inferiore a 10 cifre"
+    low-balance: "<red> Il saldo della tua isola non è abbastanza alto!"
+    too-low: "<red> Il saldo dell'isola è troppo basso."
+    must-be-a-number: "<red> L'importo deve essere un numero"
+    no-rank: "<red> Il tuo grado non è sufficientemente alto per utilizzare la banca."
+    too-much: "<red> Non hai quell'importo da depositare."
+    value-must-be-positive: "<red> L'importo deve essere positivo."
+    scientific: "<red> La notazione scientifica non è supportata."
+    too-long: "<red> Il valore deve essere inferiore a 10 cifre"
   statement:
     balance:
-      name: "&9 Saldo:"
-      description: "&6 [number]"
+      name: "<blue> Saldo:"
+      description: "<gold> [number]"
     deposit: Deposito
     description: mostra la cronologia della banca della tua isola
     give: Regalo amministratore
@@ -57,10 +57,10 @@ bank:
     oldest: Ordina per più vecchio
     set: Impostazione amministratore
     syntax: |
-      &9 [date]
-      &9 [time]
-      &7 [name]
-      &6 [number]
+      <blue> [date]
+      <blue> [time]
+      <gray> [name]
+      <gold> [number]
     take: Presa amministrativa
     title: Cronologia del conto
     unknown: Tipo sconosciuto
@@ -70,12 +70,12 @@ bank:
   withdraw:
     description: prelevare l'importo dal conto dell'isola
     parameters: "<importo>"
-    success: "&Fatto! Il tuo nuovo saldo bancario sull'isola è [number]."
+    success: "<white>atto! Il tuo nuovo saldo bancario sull'isola è [number]."
     alert: "&un [name] ritirò [number] dalla banca dell'isola."
 protection:
   flags:
     BANK_ACCESS:
       description: |-
-        &f Consenti accesso a
-        &f la banca dell'isola
+        <white> Consenti accesso a
+        <white> la banca dell'isola
       name: Accesso alla banca dell'isola

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<プレーヤー> <金額>"
       description: プレイヤーのアイランドアカウントに金額を追加する
-      success: "&a成功！ [name]の島の銀行残高は[number]になりました。"
+      success: "<green>成功！ [name]の島の銀行残高は[number]になりました。"
     take:
       parameters: "<プレーヤー> <金額>"
       description: プレイヤーのアイランドアカウントから金額を取得します
@@ -15,38 +15,38 @@ bank:
     set:
       parameters: "<プレーヤー> <金額>"
       description: プレイヤーのアイランドアカウントに金額を設定する
-      success: "&a[name]のアカウントが[number]に設定されています。"
+      success: "<green>[name]のアカウントが[number]に設定されています。"
     statement:
       parameters: "<プレイヤー>"
       description: プレイヤーのアイランドバンクステートメントを表示
   balance:
     description: 島の銀行の残高を表示します
-    island-balance: "&a島の銀行残高は[number]です。"
+    island-balance: "<green>島の銀行残高は[number]です。"
   baltop:
     description: バランスランキングを表示する
-    description-syntax: "&d[number]"
+    description-syntax: "<light_purple>[number]"
     highest: 最高で並べ替え
     lowest: 最低で並べ替え
-    name-syntax: "&d[name]"
+    name-syntax: "<light_purple>[name]"
     title: トップバランス
   deposit:
     description: 島の口座に入金金額
     parameters: "<金額>"
-    success: "&a成功！新しい島の銀行の残高は[number]です。"
+    success: "<green>成功！新しい島の銀行の残高は[number]です。"
   errors:
-    bank-error: "&c銀行口座情報の読み込み中にエラーが発生しました-後でもう一度お試しください"
-    low-balance: "&cあなたの島の銀行の残高は十分に高くありません！"
+    bank-error: "<red>銀行口座情報の読み込み中にエラーが発生しました-後でもう一度お試しください"
+    low-balance: "<red>あなたの島の銀行の残高は十分に高くありません！"
     too-low: "＆cアイランドバランスが低すぎます。"
-    must-be-a-number: "&c金額は数値である必要があります"
-    no-rank: "&cあなたのランクは銀行を使うのに十分高くありません。"
-    too-much: "&cデポジットする金額がありません。"
-    value-must-be-positive: "&c金額は正でなければなりません。"
+    must-be-a-number: "<red>金額は数値である必要があります"
+    no-rank: "<red>あなたのランクは銀行を使うのに十分高くありません。"
+    too-much: "<red>デポジットする金額がありません。"
+    value-must-be-positive: "<red>金額は正でなければなりません。"
     scientific: "＆c科学的記数法はサポートされていません。"
-    too-long: "&c値は10桁未満である必要があります"
+    too-long: "<red>値は10桁未満である必要があります"
   statement:
     balance:
-      name: "&9 銀行預金残高:"
-      description: "&6 [number]"
+      name: "<blue> 銀行預金残高:"
+      description: "<gold> [number]"
     deposit: 預り金
     description: 島の銀行の歴史を表示する
     give: 管理者が与える
@@ -54,7 +54,7 @@ bank:
     latest: 最新のもので並べ替え
     oldest: 最も古いもので並べ替え
     set: 管理者セット
-    syntax: "&9 [date] \n&9 [time] \n&7 [name] \n&6 [number]"
+    syntax: "<blue> [date] \n<blue> [time] \n<gray> [name] \n<gold> [number]"
     take: 管理者テイク
     title: アカウント履歴
     unknown: 不明なタイプ
@@ -64,11 +64,11 @@ bank:
   withdraw:
     description: アイランドアカウントから金額を引き出す
     parameters: "<金額>"
-    success: "&a成功！新しい島の銀行の残高は[number]です。"
+    success: "<green>成功！新しい島の銀行の残高は[number]です。"
 protection:
   flags:
     BANK_ACCESS:
       description: |-
-        &f島の銀行への
-        &fアクセスを許可する
+        <white>島の銀行への
+        <white>アクセスを許可する
       name: アイランドバンクアクセス

--- a/src/main/resources/locales/ko.yml
+++ b/src/main/resources/locales/ko.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<플레이어> <금액>"
       description: 플레이어의 섬 은행에 입금합니다.
-      success: "&a성공적으로 지급되었습니다! [name]님의 섬 은행 잔고는 [number]원 입니다."
+      success: "<green>성공적으로 지급되었습니다! [name]님의 섬 은행 잔고는 [number]원 입니다."
     take:
       parameters: "<플레이어> <금액>"
       description: 플레이어 섬 은행에서 출금합니다.
@@ -15,39 +15,39 @@ bank:
     set:
       parameters: "<플레이어> <금액>"
       description: 플레이어의 섬 은행 잔고를 설정합니다.
-      success: "&a[name]님의 섬 은행 잔고가[number]원으로 설정되었습니다."
+      success: "<green>[name]님의 섬 은행 잔고가[number]원으로 설정되었습니다."
     statement:
       parameters: "<플레이어>"
       description: 플레이어에 대한 섬 은행 명세서를 확인합니다.
   balance:
     description: 섬 은행 잔고를 확인합니다.
-    island-balance: "&a섬 은행 잔고는 [number]원입니다."
+    island-balance: "<green>섬 은행 잔고는 [number]원입니다."
   baltop:
     description: 섬 은행 순위를 확인합니다.
-    description-syntax: "&d[number]"
+    description-syntax: "<light_purple>[number]"
     highest: 오름차순 정렬
     lowest: 내림차순 정렬
-    name-syntax: "&d[name]"
+    name-syntax: "<light_purple>[name]"
     title: 섬 은행 순위
   deposit:
     description: 자신의 섬 은행에 입금합니다.
     parameters: "<금액>"
-    success: "&a성공적으로 입금되었습니다! 현재 섬 은행 잔고는 [number]입니다."
-    alert: "&a[name]님이 [number]원을 입금하였습니다."
+    success: "<green>성공적으로 입금되었습니다! 현재 섬 은행 잔고는 [number]입니다."
+    alert: "<green>[name]님이 [number]원을 입금하였습니다."
   errors:
-    bank-error: "&c은행 정보를 불러오는 동안 오류가 발생했습니다. 나중에 다시 시도하십시오."
-    low-balance: "&c섬 은행 잔고가 충분하지 않습니다!"
-    too-low: "&c섬 은행 잔고가 너무 낮습니다."
-    must-be-a-number: "&c금액은 숫자여야 합니다."
-    no-rank: "&c랭크가 낮아 은행을 이용할 수 없습니다."
-    too-much: "&c섬 은행에 입금할 금액이 없습니다."
-    value-must-be-positive: "&c금액은 양수여야 합니다."
-    scientific: "&c과학적 표기법은 지원되지 않습니다."
-    too-long: "&c값은 10자리 미만이어야 합니다"
+    bank-error: "<red>은행 정보를 불러오는 동안 오류가 발생했습니다. 나중에 다시 시도하십시오."
+    low-balance: "<red>섬 은행 잔고가 충분하지 않습니다!"
+    too-low: "<red>섬 은행 잔고가 너무 낮습니다."
+    must-be-a-number: "<red>금액은 숫자여야 합니다."
+    no-rank: "<red>랭크가 낮아 은행을 이용할 수 없습니다."
+    too-much: "<red>섬 은행에 입금할 금액이 없습니다."
+    value-must-be-positive: "<red>금액은 양수여야 합니다."
+    scientific: "<red>과학적 표기법은 지원되지 않습니다."
+    too-long: "<red>값은 10자리 미만이어야 합니다"
   statement:
     balance:
-      name: "&9은행 잔고:"
-      description: "&6[number]"
+      name: "<blue>은행 잔고:"
+      description: "<gold>[number]"
     deposit: 예금
     description: 섬 은행 기록을 확인합니다.
     give: 관리자 입금
@@ -56,10 +56,10 @@ bank:
     oldest: 지난순
     set: 관리자 설정
     syntax: |
-      &9[date]
-      &9[time]
-      &7[name]
-      &6[number]
+      <blue>[date]
+      <blue>[time]
+      <gray>[name]
+      <gold>[number]
     take: 관리자 출금
     title: 계정 내역
     unknown: 알 수 없는 유형
@@ -69,12 +69,12 @@ bank:
   withdraw:
     description: 섬 은행에서 금액을 인출합니다.
     parameters: "<금액>"
-    success: "&a성공적으로 출금하였습니다! 현재 섬 은행 잔고는 [number]입니다."
-    alert: "&a[name]님이 [number]원을 출금하였습니다."
+    success: "<green>성공적으로 출금하였습니다! 현재 섬 은행 잔고는 [number]입니다."
+    alert: "<green>[name]님이 [number]원을 출금하였습니다."
 protection:
   flags:
     BANK_ACCESS:
       description: |-
-        &f섬의 은행 접근을
-        &f허가합니다.
+        <white>섬의 은행 접근을
+        <white>허가합니다.
       name: 섬 은행 접근

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<player> <amount>"
       description: додати суму на рахунок острова гравця
-      success: "&a Успіх! Баланс острівного банку [name] тепер становить [number]."
+      success: "<green> Успіх! Баланс острівного банку [name] тепер становить [number]."
     take:
       parameters: "<player> <amount>"
       description: взяти суму з острівного рахунку гравця
@@ -21,34 +21,34 @@ bank:
       description: переглянути виписку з банківського рахунку острова для гравця
   balance:
     description: показує баланс вашого острівного банку
-    island-balance: "&a Баланс банку острова [number]."
+    island-balance: "<green> Баланс банку острова [number]."
   baltop:
     description: показати рейтинг балансу
-    description-syntax: "&d [number]"
+    description-syntax: "<light_purple> [number]"
     highest: Сортувати за найвищим
     lowest: Сортувати за найнижчим
-    name-syntax: "&d [name]"
+    name-syntax: "<light_purple> [name]"
     title: Топ баланси
   deposit:
     description: внесіть суму на свій острівний рахунок
     parameters: "<amount>"
-    success: "&a Успіх! Ваш новий баланс в острівному банку становить [number]."
-    alert: "&a [name] вніс [number] в острівний банк."
+    success: "<green> Успіх! Ваш новий баланс в острівному банку становить [number]."
+    alert: "<green> [name] вніс [number] в острівний банк."
   errors:
-    bank-error: "&c Помилка завантаження інформації про банківський рахунок - спробуйте
+    bank-error: "<red> Помилка завантаження інформації про банківський рахунок - спробуйте
       пізніше"
-    low-balance: "&c Баланс вашого острівного банку недостатньо високий!"
-    too-low: "&c Баланс острова занадто низький."
-    must-be-a-number: "&c Сума має бути числом"
-    no-rank: "&c Ваш ранг недостатньо високий, щоб користуватися банком."
-    too-much: "&c У вас немає такої суми для депозиту."
-    value-must-be-positive: "&c Сума має бути додатною."
-    scientific: "&c Наукова нотація не підтримується."
-    too-long: "&c Значення має бути меншим за 10 цифр"
+    low-balance: "<red> Баланс вашого острівного банку недостатньо високий!"
+    too-low: "<red> Баланс острова занадто низький."
+    must-be-a-number: "<red> Сума має бути числом"
+    no-rank: "<red> Ваш ранг недостатньо високий, щоб користуватися банком."
+    too-much: "<red> У вас немає такої суми для депозиту."
+    value-must-be-positive: "<red> Сума має бути додатною."
+    scientific: "<red> Наукова нотація не підтримується."
+    too-long: "<red> Значення має бути меншим за 10 цифр"
   statement:
     balance:
-      name: "&9 Баланс:"
-      description: "&6 [number]"
+      name: "<blue> Баланс:"
+      description: "<gold> [number]"
     deposit: Депозит
     description: показати історію вашого острівного банку
     give: Адмін видати
@@ -57,10 +57,10 @@ bank:
     oldest: Сортувати за найстарішим
     set: Адмін встановити
     syntax: |
-      &9 [date]
-      &9 [time]
-      &7 [name]
-      &6 [number]
+      <blue> [date]
+      <blue> [time]
+      <gray> [name]
+      <gold> [number]
     take: Адмін забрати
     title: Історія облікового запису
     unknown: Невідомий тип
@@ -70,12 +70,12 @@ bank:
   withdraw:
     description: зняти суму зі свого острівного рахунку
     parameters: "<amount>"
-    success: "&a Успіх! Ваш новий баланс у острівному банку становить [number]."
-    alert: "&a [name] зняв [number] з острівного банку."
+    success: "<green> Успіх! Ваш новий баланс у острівному банку становить [number]."
+    alert: "<green> [name] зняв [number] з острівного банку."
 protection:
   flags:
     BANK_ACCESS:
       description: |-
-        &f Дозволити доступ до
-        &f острівний банк
+        <white> Дозволити доступ до
+        <white> острівний банк
       name: Доступ до банку острова

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<người chơi> <số tiền>"
       description: thêm số tiền vào tài khoản đảo của người chơi
-      success: "&a Thành công! Số dư ngân hàng đảo của [name] hiện là [number]."
+      success: "<green> Thành công! Số dư ngân hàng đảo của [name] hiện là [number]."
     take:
       parameters: "<người chơi> <số tiền>"
       description: lấy số tiền từ tài khoản đảo của người chơi
@@ -15,39 +15,39 @@ bank:
     set:
       parameters: "<người chơi> <số lượng>"
       description: đặt số tiền trong tài khoản đảo của người chơi
-      success: " &a Tài khoản của [name] được đặt thành [number]."
+      success: " <green> Tài khoản của [name] được đặt thành [number]."
     statement:
       parameters: "<người chơi>"
       description: xem đảo sao kê ngân hàng cho người chơi
   balance:
     description: hiển thị số dư ngân hàng đảo của bạn
-    island-balance: "&a Số dư ngân hàng đảo là [number]."
+    island-balance: "<green> Số dư ngân hàng đảo là [number]."
   baltop:
     description: hiển thị thứ hạng ngân hàng
-    description-syntax: "&d [number]"
+    description-syntax: "<light_purple> [number]"
     highest: Sắp xếp theo Cao nhất
     lowest: Sắp xếp theo Thấp nhất
-    name-syntax: "&d [name]"
+    name-syntax: "<light_purple> [name]"
     title: Số dư hàng đầu
   deposit:
     description: số tiền gửi vào tài khoản đảo của bạn
     parameters: "<số tiền>"
-    success: "&a Thành công! Số dư ngân hàng đảo mới của bạn là [number]."
-    alert: "&a [name] đã gửi [number] vào ngân hàng của đảo."
+    success: "<green> Thành công! Số dư ngân hàng đảo mới của bạn là [number]."
+    alert: "<green> [name] đã gửi [number] vào ngân hàng của đảo."
   errors:
-    bank-error: "&c Lỗi khi tải thông tin tài khoản ngân hàng - vui lòng thử lại sau"
-    low-balance: "&c Số dư ngân hàng đảo của bạn không đủ cao!"
-    too-low: "&c Số tiền của đảo quá thấp."
-    must-be-a-number: "&c Số tiền phải là một số"
-    no-rank: "&c Xếp hạng của bạn không đủ cao để sử dụng ngân hàng."
-    too-much: "&c Bạn không có số tiền đó để gửi."
-    value-must-be-positive: "&c Số tiền phải là số dương."
-    scientific: "&c Ký hiệu khoa học không được hỗ trợ."
-    too-long: "&c Giá trị phải nhỏ hơn 10 chữ số"
+    bank-error: "<red> Lỗi khi tải thông tin tài khoản ngân hàng - vui lòng thử lại sau"
+    low-balance: "<red> Số dư ngân hàng đảo của bạn không đủ cao!"
+    too-low: "<red> Số tiền của đảo quá thấp."
+    must-be-a-number: "<red> Số tiền phải là một số"
+    no-rank: "<red> Xếp hạng của bạn không đủ cao để sử dụng ngân hàng."
+    too-much: "<red> Bạn không có số tiền đó để gửi."
+    value-must-be-positive: "<red> Số tiền phải là số dương."
+    scientific: "<red> Ký hiệu khoa học không được hỗ trợ."
+    too-long: "<red> Giá trị phải nhỏ hơn 10 chữ số"
   statement:
     balance:
-      name: "&9 Số dư:"
-      description: "&6 [number]"
+      name: "<blue> Số dư:"
+      description: "<gold> [number]"
     deposit: Tiền gửi
     description: hiển thị lịch sử ngân hàng đảo của bạn
     give: Quản trị viên cho
@@ -56,10 +56,10 @@ bank:
     oldest: Sắp xếp theo cũ nhất
     set: Bộ quản trị
     syntax: |-
-      &9 [date]
-      &9 [time]
-      &7 [name]
-      &6 [number]
+      <blue> [date]
+      <blue> [time]
+      <gray> [name]
+      <gold> [number]
     take: quản trị viên lấy tiền
     title: Lịch sử tài khoản
     unknown: Loại không xác định
@@ -69,12 +69,12 @@ bank:
   withdraw:
     description: rút số tiền từ tài khoản đảo của bạn
     parameters: "<số tiền>"
-    success: "&a Thành công! Số dư ngân hàng đảo mới của bạn là [number]."
-    alert: "&a [name] đã rút [number] khỏi ngân hàng của đảo."
+    success: "<green> Thành công! Số dư ngân hàng đảo mới của bạn là [number]."
+    alert: "<green> [name] đã rút [number] khỏi ngân hàng của đảo."
 protection:
   flags:
     BANK_ACCESS:
       description: |-
-        &f Cho phép truy cập vào
-        &f ngân hàng của đảo
+        <white> Cho phép truy cập vào
+        <white> ngân hàng của đảo
       name: Truy cập ngân hàng đảo

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -5,7 +5,7 @@ bank:
     give:
       parameters: "<玩家> <金额>"
       description: 向玩家的空岛银行增加金钱
-      success: "&a成功！ [name] 的岛屿银行余额现在是 [number]"
+      success: "<green>成功！ [name] 的岛屿银行余额现在是 [number]"
     take:
       parameters: "<玩家> <金额>"
       description: 从玩家的岛屿账户中取出金钱
@@ -15,39 +15,39 @@ bank:
     set:
       parameters: "<玩家> <金额>"
       description: 设置玩家岛屿账户的金额
-      success: "&a [name] 的帐户金额设置为[number]"
+      success: "<green> [name] 的帐户金额设置为[number]"
     statement:
       parameters: "<玩家>"
       description: 查看玩家的岛上银行帐单
   balance:
     description: 显示您的岛屿银行余额
-    island-balance: "&a岛银行的余额为[number]。"
+    island-balance: "<green>岛银行的余额为[number]。"
   baltop:
     description: 显示余额排名
-    description-syntax: "&d[number]"
+    description-syntax: "<light_purple>[number]"
     highest: 降序排序
     lowest: 升序排序
-    name-syntax: "&d[name]"
+    name-syntax: "<light_purple>[name]"
     title: 最高余额
   deposit:
     description: 将金额存入您的岛屿账户
     parameters: "<金额>"
     success: "＆成功！您的新岛银行余额为[number]。"
-    alert: "&a [name]向岛屿银行存入了[number]。"
+    alert: "<green> [name]向岛屿银行存入了[number]。"
   errors:
     bank-error: "＆c加载银行帐户信息时出错-请稍后重试"
     low-balance: "＆c您的岛屿银行余额不足！"
-    too-low: "&c 空岛余额太少"
+    too-low: "<red> 空岛余额太少"
     must-be-a-number: "＆c金额必须是数字"
     no-rank: "＆c您的等级不够高，无法使用银行。"
     too-much: "＆c您没有足够的钱来存入。"
     value-must-be-positive: "＆c金额必须为正数。"
-    scientific: "&c 不支持科学记数法。"
-    too-long: "&c 值必须小于 10 位"
+    scientific: "<red> 不支持科学记数法。"
+    too-long: "<red> 值必须小于 10 位"
   statement:
     balance:
-      name: "&9 银行存款余额:"
-      description: "&6 [number]"
+      name: "<blue> 银行存款余额:"
+      description: "<gold> [number]"
     deposit: 存入
     description: 显示您的岛屿银行历史
     give: 管理员给予
@@ -55,7 +55,7 @@ bank:
     latest: 按最新排序
     oldest: 按最旧排序
     set: 管理员设置
-    syntax: "&9 [date] \n&9 [time] \n&7 [name]\n &6 [number]"
+    syntax: "<blue> [date] \n<blue> [time] \n<gray> [name]\n <gold> [number]"
     take: 管理员拿走
     title: 账户历史
     unknown: 未知类型
@@ -65,10 +65,10 @@ bank:
   withdraw:
     description: 从您的岛屿账户中提款
     parameters: "<金额>"
-    success: "&a成功！您的新岛银行余额为[number]。"
-    alert: "&a [name]从岛屿银行取出了[number]。"
+    success: "<green>成功！您的新岛银行余额为[number]。"
+    alert: "<green> [name]从岛屿银行取出了[number]。"
 protection:
   flags:
     BANK_ACCESS:
-      description: "&f允许使用空岛银行"
+      description: "<white>允许使用空岛银行"
       name: 空岛银行权限


### PR DESCRIPTION
Replace all legacy ampersand color codes (&a, &c, &9, etc.) with their MiniMessage tag equivalents (<green>, <red>, <blue>, ...) across the 12 locale files. BentoBox renders MiniMessage natively. 292 codes converted; all files validated as YAML and rendering is unchanged (open tags apply to the rest of the string, matching legacy semantics).